### PR TITLE
fix: fix shielded balance check

### DIFF
--- a/apps/web/src/hooks/useShieldedBalances.ts
+++ b/apps/web/src/hooks/useShieldedBalances.ts
@@ -48,9 +48,28 @@ export const useShieldedBalances = (): {
 }
 
 export function hasShieldedBalance() {
-  const bermuda = useBermuda()
+  const { sdk } = useBermuda()
+
   const shieldedBalances = useShieldedBalances()
-  const hasShieldedAssets = Number(shieldedBalances.balances.items.find(b => b.tokenInfo.address === bermuda.sdk.config.mockUSDC)?.balance) > 0
-    || Number(shieldedBalances.balances.items.find(b => b.tokenInfo.address === bermuda.sdk.config.mockWETH)?.balance) > 0
+
+  let hasShieldedAssets = false
+
+  if (shieldedBalances && sdk) {
+    const mockUSDCAddress = sdk.config.mockUSDC.toLowerCase()
+    const mockWETHAddress = sdk.config.mockWETH.toLowerCase()
+
+    const total = shieldedBalances.balances.items.reduce((accum, item) => {
+      const tokenAddress = item.tokenInfo.address.toLowerCase()
+
+      if (tokenAddress === mockUSDCAddress || tokenAddress === mockWETHAddress) {
+        return (accum += Number(item.balance))
+      }
+
+      return accum
+    }, 0)
+
+    hasShieldedAssets = !!total
+  }
+
   return hasShieldedAssets
 }


### PR DESCRIPTION
Fixes the check whether the Safe has shielded assets. This then "unlocks" the "Send shielded tokens" button in the "New transaction" view.

Based on my read the core issue was the missing `toLowerCase()` for addresses.