### PR TITLE
fix: tx flow popping too many mm windows

### DIFF
--- a/apps/web/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/apps/web/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -97,17 +97,18 @@ export const useTxActions = (): TxActions => {
       if (!targetTxId) {
         const tx = await _propose(signer.address, safeTx, txId, origin)
         targetTxId = tx.txId
+      } else {
+        await dispatchOnChainSigning(
+          safeTx,
+          targetTxId,
+          signer.provider,
+          chainId,
+          signer.address,
+          safeAddress,
+          Boolean(isSmartAccount),
+        )
       }
 
-      await dispatchOnChainSigning(
-        safeTx,
-        targetTxId,
-        signer.provider,
-        chainId,
-        signer.address,
-        safeAddress,
-        Boolean(isSmartAccount),
-      )
       return targetTxId
     }
 

--- a/apps/web/src/services/bermuda/buildShieldedDeposit.ts
+++ b/apps/web/src/services/bermuda/buildShieldedDeposit.ts
@@ -147,12 +147,7 @@ export const buildShieldedDepositMetaTxs = async ({
     includesApproval: !isNativeToken,
   })
 
-  const batchSafeTxs: BatchSafeTx[] = metaTxs.map((metaTx) => ({
-    to: metaTx.to,
-    data: metaTx.data ?? '0x',
-    value: BigInt(metaTx.value ?? '0'),
-    operation: Number(metaTx.operation ?? OperationType.Call),
-  }))
+  const batchSafeTxs: BatchSafeTx[] = []
 
   return { metaTxs, batchSafeTxs, viewingKey }
 }

--- a/apps/web/src/services/tx/tx-sender/utils.ts
+++ b/apps/web/src/services/tx/tx-sender/utils.ts
@@ -2,7 +2,7 @@ import { getBermudaSDK } from '@/hooks/bermudaSDK/useBermudaSDK'
 import { SafeTransactionData } from '@safe-global/types-kit'
 import { Contract, Interface, getBytes, Signer } from 'ethers'
 
-export async function getSafeTxHash(safeAddress: string, safeTxData: SafeTransactionData) {
+export async function getSafeTxHash(safeAddress: string, safeTxData: SafeTransactionData): Promise<string> {
     const bermudaSDK = getBermudaSDK()
     const safeContract = new Contract(
         safeAddress,
@@ -33,22 +33,22 @@ export async function getAdjustedSignature(signer: Signer, safeTxHash: string): 
 }
 
 export async function getConfirmPayload(
-  safeAddress: string,
-  safeTxHash: string,
-  signer: Signer,
+    safeAddress: string,
+    safeTxHash: string,
+    signer: Signer,
 ): Promise<{ to: string; data: string }> {
-  const bermudaSDK = getBermudaSDK()
-  const signature = await getAdjustedSignature(signer, safeTxHash)
+    const bermudaSDK = getBermudaSDK()
+    const signature = await getAdjustedSignature(signer, safeTxHash)
 
-  const proposeTxLib = bermudaSDK.config.proposeTxLib
-  if (!proposeTxLib) {
-    throw new Error('ProposeTxLib address not configured')
-  }
+    const proposeTxLib = bermudaSDK.config.proposeTxLib
+    if (!proposeTxLib) {
+        throw new Error('ProposeTxLib address not configured')
+    }
 
-  const iface = Interface.from(bermudaSDK.abis.PROPOSE_TX_LIB_ABI)
+    const iface = Interface.from(bermudaSDK.abis.PROPOSE_TX_LIB_ABI)
 
-  return {
-    to: proposeTxLib,
-    data: iface.encodeFunctionData('confirm', [safeAddress, safeTxHash, signature]),
-  }
+    return {
+        to: proposeTxLib,
+        data: iface.encodeFunctionData('confirm', [safeAddress, safeTxHash, signature]),
+    }
 }


### PR DESCRIPTION
## What it solves

Solves the Safe tx flow popping up the many MetaMask sig/tx windows.

Now both proposal and confirmation both correctly first popup a window for signing the Safe tx hash, and then popping another for the tx dispatch confirmation.