### PR TITLE
feat: integration transaction pages

### DIFF
--- a/apps/web/src/components/transactions/SingleTx/index.tsx
+++ b/apps/web/src/components/transactions/SingleTx/index.tsx
@@ -16,6 +16,7 @@ import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 import { useGetTransactionDetailsQuery } from '@/store/api/gateway'
 import { skipToken } from '@reduxjs/toolkit/query/react'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
+import useLoadTransactionDetails from '@/on-chain-data/hooks/useLoadTransactionDetails'
 
 const SingleTxGrid = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement => {
   const tx: Transaction = makeTxFromDetails(txDetails)
@@ -56,6 +57,15 @@ const SingleTx = () => {
       : skipToken,
   )
 
+  // Load Transaction Details via on-chain data.
+  const chainId = Number(safe.chainId)
+  const { data: ocTxDetails, error: ocTxDetailsError } = useLoadTransactionDetails(chainId, safeAddress, transactionId)
+
+  if (!txDetails) {
+    txDetails = ocTxDetails
+    txDetailsError = ocTxDetailsError
+  }
+
   useEffect(() => {
     !isUninitialized && refetch()
   }, [safe.txHistoryTag, safe.txQueuedTag, safeAddress, refetch, isUninitialized])
@@ -64,7 +74,7 @@ const SingleTx = () => {
     txDetailsError = new Error('Transaction with this id was not found in this Safe Account')
   }
 
-  if (txDetailsError) {
+  if (!txDetails && txDetailsError) {
     return <ErrorMessage error={asError(txDetailsError)}>Failed to load transaction</ErrorMessage>
   }
 

--- a/apps/web/src/on-chain-data/hooks/useLoadTransactionDetails.ts
+++ b/apps/web/src/on-chain-data/hooks/useLoadTransactionDetails.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import loadSafeInfo from '../load-safe-info'
+import { useBermuda } from '@/contexts/bermuda-context'
+import { toTransactionDetails } from '@/services/bermuda/txMapper'
+import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+
+export default function useLoadTransactionDetails(chainId: number, address: string, transactionId?: string) {
+  const { sdk } = useBermuda()
+  const [error, setError] = useState<Error>()
+  const [data, setData] = useState<TransactionDetails>()
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+
+  async function load(transactionId: string) {
+    setIsLoading(true)
+
+    try {
+      const { owners, threshold } = await loadSafeInfo(chainId, address)
+
+      let txHash = transactionId
+      if (txHash.startsWith('multisig')) {
+        txHash = transactionId.split('_').pop()!
+      }
+
+      const { all } = await sdk.safe.listTxs(address)
+      const transaction = all.find((item: any) => item.hash.toLowerCase() === txHash.toLowerCase())
+
+      const entry = {
+        safeAddress: address,
+        info: transaction,
+        timestamp: Date.now(),
+      }
+
+      const details = toTransactionDetails(entry, owners, threshold)
+
+      setData(details)
+    } catch (error: unknown) {
+      setError(error as Error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (sdk && transactionId) {
+      load(transactionId)
+    }
+  }, [sdk, transactionId])
+
+  return { data, isLoading, error }
+}

--- a/apps/web/src/pages/transactions/index.tsx
+++ b/apps/web/src/pages/transactions/index.tsx
@@ -1,3 +1,3 @@
-import HistoryPage from './history'
+import QueuePage from './queue'
 
-export default HistoryPage
+export default QueuePage

--- a/apps/web/src/services/bermuda/txMapper.ts
+++ b/apps/web/src/services/bermuda/txMapper.ts
@@ -81,7 +81,7 @@ const toTransaction = (
   }
 }
 
-const toTransactionDetails = (
+export const toTransactionDetails = (
   cacheEntry: CachedSdkTx,
   owners: AddressEx[],
   threshold: number,


### PR DESCRIPTION
This PR ensures that the transaction pages are working properly.

The index page for transactions is now set to the queue page (as history will be WIP). If one clicks on a transaction detail we're now first checking via the API and then falling back to on-chain data to fetch the details to be displayed.