### PR TITLE
feat: implement component for shielded tx details

### DIFF
--- a/apps/web/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/apps/web/src/components/transactions/ExecuteTxButton/index.tsx
@@ -1,7 +1,7 @@
 import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
 import useIsPending from '@/hooks/useIsPending'
 import type { SyntheticEvent } from 'react'
-import { type ReactElement, useContext, useEffect, useState } from 'react'
+import { type ReactElement, useContext, useState } from 'react'
 import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { Button, CircularProgress, Tooltip } from '@mui/material'
 
@@ -29,7 +29,7 @@ const ExecuteTxButton = ({
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
   const isPending = useIsPending(txSummary.id)
   const { setSelectedTxId } = useContext(ReplaceTxHoverContext)
-  const { keyPair, sdk, saveStxExecuted, isStxExecuted, stxType } = useBermuda()
+  const { keyPair, sdk, saveStxExecuted, isStxExecuted, stxInfo } = useBermuda()
   const [isDispatchingProofs, setIsDispatchingProofs] = useState(false)
 
   const expiredSwap = useIsExpiredSwap(txSummary.txInfo)
@@ -38,7 +38,7 @@ const ExecuteTxButton = ({
   const isStxTransferOrUnshield = methodName === "Shielded transfer" || methodName === "Unshield"
 
   const isNext = (txNonce !== undefined && txNonce === safe.nonce) //|| problyStx
-  const _isStxExecuted = sdk && isStxExecuted(txSummary.txHash!.toLowerCase())
+  const _isStxExecuted = sdk && txSummary.txHash && isStxExecuted(txSummary.txHash.toLowerCase())
   const isDisabled = _isStxExecuted || isDispatchingProofs || !isStxTransferOrUnshield && (!isNext || !sdk || expiredSwap || isPending)
 
   const onClick = async (e: SyntheticEvent) => {
@@ -49,13 +49,13 @@ const ExecuteTxButton = ({
       try {
         setIsDispatchingProofs(true)
         console.log(isDispatchingProofs)
-        console.log("$$$$$ stxType", stxType, "stxType === STXType.Withdrawal", stxType === STXType.Withdrawal)
-        if (stxType === STXType.Transfer) {
+        console.log("$$$$$ stxInfo?.type", stxInfo?.type, "stxInfo?.type === STXType.Withdrawal", stxInfo?.type === STXType.Withdrawal)
+        if (stxInfo?.type === STXType.Transfer) {
           await dispatchShieldedTransfer(keyPair, safe.address.value, txSummary)
-        } else if (stxType === STXType.Withdrawal) {
+        } else if (stxInfo?.type === STXType.Withdrawal) {
           await dispatchShieldedWithdrawal(keyPair, safe.address.value, txSummary)
         } else {
-          throw Error("Unexpected stx type " + stxType)
+          throw Error("Unexpected stx type " + stxInfo?.type)
         }
 
         saveStxExecuted(txSummary.txHash!.toLowerCase())

--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -6,6 +6,8 @@ import type { SafeTransactionData } from '@safe-global/types-kit'
 import { dateString } from '@safe-global/utils/utils/formatters'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import { Receipt } from '@/components/tx/ConfirmTxDetails/Receipt'
+import { ShieldedReceipt } from '@/components/tx/ConfirmTxDetails/ShieldedReceipt'
+import { useState, useEffect } from 'react'
 import DecodedData from '../TxData/DecodedData'
 import ColorCodedTxAccordion from '@/components/tx/ColorCodedTxAccordion'
 import { Box, Divider, Stack, Typography } from '@mui/material'
@@ -13,6 +15,9 @@ import DecoderLinks from './DecoderLinks'
 import isEqual from 'lodash/isEqual'
 import Multisend from '../TxData/DecodedData/Multisend'
 import { isMultiSendCalldata } from '@/utils/transaction-calldata'
+import { useBermuda } from '@/contexts/bermuda-context'
+import { getTxHash } from '@/services/bermuda/txMapper'
+import { type SafeStxHashParams } from '@/services/bermuda/types'
 
 interface Props {
   safeTxData?: SafeTransactionData
@@ -31,6 +36,21 @@ const Summary = ({
   showMultisend = true,
   showDecodedData = true,
 }: Props): ReactElement => {
+  const { getStxPreimage } = useBermuda()
+  const [stxPreimage, setStxPreimage] = useState<SafeStxHashParams | undefined>()
+
+  useEffect(() => {
+    if (txDetails) {
+      async function run() {
+        const txHash = getTxHash(txDetails?.txId!)
+        const preimage = await getStxPreimage(txHash)
+
+        setStxPreimage(preimage)
+      }
+      run()
+    }
+  }, [txDetails, getStxPreimage])
+
   const { txHash, executedAt } = txDetails ?? {}
   const customTxInfo = txInfo && isCustomTxInfo(txInfo) ? txInfo : undefined
   const toInfo = customTxInfo?.to || txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
@@ -93,20 +113,32 @@ const Summary = ({
               {showDecodedData && <DecodedData txData={txData} toInfo={toInfo} />}
 
               <Box>
-                <Typography variant="subtitle2" fontWeight={700} mb={2}>
-                  Advanced details
-                </Typography>
+                {stxPreimage ? (
+                  <ShieldedReceipt
+                    safeTxData={safeTxData}
+                    shieldedTxData={stxPreimage}
+                    txData={txData}
+                    txInfo={txInfo}
+                    grid
+                  />
+                ) : (
+                  <>
+                    <Typography variant="subtitle2" fontWeight={700} mb={2}>
+                      Advanced details
+                    </Typography>
 
-                <DecoderLinks />
+                    <DecoderLinks />
 
-                <Receipt
-                  safeTxData={safeTxData}
-                  txData={txData}
-                  txDetails={txDetails}
-                  txInfo={txInfo}
-                  withSignatures
-                  grid
-                />
+                    <Receipt
+                      safeTxData={safeTxData}
+                      txData={txData}
+                      txDetails={txDetails}
+                      txInfo={txInfo}
+                      withSignatures
+                      grid
+                    />
+                  </>
+                )}
               </Box>
             </Stack>
           </ColorCodedTxAccordion>

--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -101,7 +101,7 @@ export const TxFlow = <T extends unknown>({
                   <Blockaid />
                 </ReviewTransactionComponent>
 
-                <ConfirmTxReceipt onSubmit={handleFlowSubmit}>
+                <ConfirmTxReceipt onSubmit={handleFlowSubmit} txId={txId}>
                   <Counterfactual />
                   <ExecuteThroughRole />
 

--- a/apps/web/src/components/tx-flow/flows/ShieldAssets/ReviewShieldAssets.tsx
+++ b/apps/web/src/components/tx-flow/flows/ShieldAssets/ReviewShieldAssets.tsx
@@ -27,7 +27,7 @@ const ReviewShieldAssets = ({
   children,
 }: PropsWithChildren<ReviewShieldAssetsProps>) => {
   const { safeAddress } = useSafeInfo()
-  const { sdk, keyPair, saveStxType } = useBermuda()
+  const { sdk, keyPair, saveStxInfo } = useBermuda()
   const { balances } = useBalances()
   const { setSafeTx, setSafeTxError, setNonce, setBatchSafeTxs } = useContext(SafeTxContext)
   const currentChain = useCurrentChain()
@@ -83,8 +83,7 @@ const ReviewShieldAssets = ({
         })
         setSafeTxError(undefined)
 
-        sdk && saveStxType(STXType.Deposit)
-        const { metaTxs, batchSafeTxs } = await buildShieldedDepositMetaTxs({
+        const { metaTxs, batchSafeTxs, shieldedTx } = await buildShieldedDepositMetaTxs({
           safeAddress,
           shieldedAddress: recipient.recipient,
           tokenAddress: recipient.tokenAddress,
@@ -92,6 +91,8 @@ const ReviewShieldAssets = ({
           amount: recipient.amount,
           shieldedKeyPair: keyPair,
         })
+
+        sdk && saveStxInfo({ type: STXType.Deposit, data: shieldedTx })
 
         const safeTx = await createMultiSendCallOnlyTx(metaTxs)
 

--- a/apps/web/src/components/tx-flow/flows/ShieldedAssetsTransfer/ReviewShieldedAssetsTransfer.tsx
+++ b/apps/web/src/components/tx-flow/flows/ShieldedAssetsTransfer/ReviewShieldedAssetsTransfer.tsx
@@ -31,7 +31,7 @@ const ReviewShieldedAssetsTransfer = ({
   const { balances } = useBalances()
   const { setSafeTx, setSafeTxError, setNonce, setBatchSafeTxs } = useContext(SafeTxContext)
   const currentChain = useCurrentChain()
-  const { sdk, saveStxType } = useBermuda()
+  const { sdk, saveStxInfo } = useBermuda()
   const { data } = useContext(TxFlowContext) as TxFlowContextType<MultiTokenTransferParams>
   const formData = params ?? data
 
@@ -83,8 +83,8 @@ const ReviewShieldedAssetsTransfer = ({
           tokenDecimals,
         })
         setSafeTxError(undefined)
-        sdk && saveStxType(STXType.Transfer)
-        const { metaTxs, batchSafeTxs } = await buildShieldedTransferMetaTxs({
+
+        const { metaTxs, batchSafeTxs, shieldedTx } = await buildShieldedTransferMetaTxs({
           safeAddress,
           shieldedAddress: recipient.recipient,
           tokenAddress: recipient.tokenAddress,
@@ -92,6 +92,8 @@ const ReviewShieldedAssetsTransfer = ({
           amount: recipient.amount,
           shieldedKeyPair: keyPair,
         })
+
+        sdk && saveStxInfo({type: STXType.Transfer, data: shieldedTx })
 
         const safeTx = await createMultiSendCallOnlyTx(metaTxs)
 

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -39,7 +39,7 @@ const SuccessScreen = ({ txId, txHash }: Props) => {
   const chain = useCurrentChain()
   const router = useRouter()
   const dispatch = useAppDispatch()
-  const { stxType } = useBermuda()
+  const { stxInfo } = useBermuda()
   const pendingTx = useAppSelector((state) => (txId ? selectPendingTxById(state, txId) : undefined))
   const { safeAddress } = useSafeInfo()
   const status = !txId && txHash ? PendingStatus.INDEXING : pendingTx?.status
@@ -99,7 +99,7 @@ const SuccessScreen = ({ txId, txHash }: Props) => {
   const spinnerStatus = error ? SpinnerStatus.ERROR : isSuccess ? SpinnerStatus.SUCCESS : SpinnerStatus.PROCESSING
 
   useEffect(() => {
-    if (isSuccess && (stxType === STXType.Transfer || stxType === STXType.Withdrawal)) {
+    if (isSuccess && (stxInfo?.type === STXType.Transfer || stxInfo?.type === STXType.Withdrawal)) {
       dispatch(
         showNotification({
           title: 'Success',
@@ -109,14 +109,14 @@ const SuccessScreen = ({ txId, txHash }: Props) => {
         }),
       )
     }
-  }, [isSuccess, stxType])
+  }, [isSuccess, stxInfo])
 
   useEffect(() => {
-    if (isSuccess && (stxType === STXType.Transfer || stxType === STXType.Withdrawal) && router.isReady) {
+    if (isSuccess && (stxInfo?.type === STXType.Transfer || stxInfo?.type === STXType.Withdrawal) && router.isReady) {
       setTxFlow(undefined)
       router.push(`/transactions/queue?safe=dev:${safeAddress}`)
     }
-  }, [isSuccess, stxType, router.isReady])
+  }, [isSuccess, stxInfo, router.isReady])
 
   let StatusComponent
   switch (status) {

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/ShieldedRecipientRow/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/ShieldedRecipientRow/index.tsx
@@ -36,7 +36,7 @@ type RecipientRowProps = {
 export const ShieldedRecipientRow = ({ fieldArray, removable = true, remove, disableSpendingLimit }: RecipientRowProps) => {
   const { balances } = useShieldedBalances()
   const spendingLimits = useSelector(selectSpendingLimits)
-  const { stxType } = useBermuda()
+  const { stxInfo } = useBermuda()
 
   const {
     formState: { errors },
@@ -96,7 +96,7 @@ export const ShieldedRecipientRow = ({ fieldArray, removable = true, remove, dis
         <Stack spacing={2}>
 
           {
-            stxType !== STXType.Withdrawal && (
+            stxInfo?.type !== STXType.Withdrawal && (
               <FormControl fullWidth>
                 <AddressBookInput name={recipientFieldName} canAdd={isAddressValid} />
               </FormControl>

--- a/apps/web/src/components/tx-flow/flows/UnshieldAssets/ReviewUnshieldAssets.tsx
+++ b/apps/web/src/components/tx-flow/flows/UnshieldAssets/ReviewUnshieldAssets.tsx
@@ -28,7 +28,7 @@ const ReviewUnshieldAssets = ({
   children,
 }: PropsWithChildren<ReviewUnshieldAssetsProps>) => {
   const { safeAddress } = useSafeInfo()
-  const { sdk, keyPair, saveStxType } = useBermuda()
+  const { sdk, keyPair, saveStxInfo } = useBermuda()
   const { balances } = useBalances()
   const { setSafeTx, setSafeTxError, setNonce, setBatchSafeTxs } = useContext(SafeTxContext)
   const currentChain = useCurrentChain()
@@ -84,8 +84,7 @@ const ReviewUnshieldAssets = ({
         })
         setSafeTxError(undefined)
 
-        sdk && saveStxType(STXType.Withdrawal)
-        const { metaTxs, batchSafeTxs } = await buildShieldedWithdrawalMetaTxs({
+        const { metaTxs, batchSafeTxs, shieldedTx } = await buildShieldedWithdrawalMetaTxs({
           safeAddress,
           nativeAddress: safeAddress,
           tokenAddress: recipient.tokenAddress,
@@ -93,6 +92,8 @@ const ReviewUnshieldAssets = ({
           amount: recipient.amount,
           shieldedKeyPair: keyPair,
         })
+
+        sdk && saveStxInfo({ type: STXType.Withdrawal, data: shieldedTx })
 
         const safeTx = await createMultiSendCallOnlyTx(metaTxs)
 

--- a/apps/web/src/components/tx/ConfirmTxDetails/ShieldedReceipt.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/ShieldedReceipt.tsx
@@ -1,0 +1,216 @@
+import { Fragment, useEffect, useState, type ReactElement } from 'react'
+import { Box, Divider, Stack, Typography } from '@mui/material'
+import type { SafeTransaction } from '@safe-global/types-kit'
+import { PaperViewToggle } from '../../common/PaperViewToggle'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import { type TransactionDetails, type TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
+import { HexEncodedData } from '@/components/transactions/HexEncodedData'
+import {
+  useDomainHash,
+  useMessageHash,
+  useSafeTxHash,
+} from '@/components/transactions/TxDetails/Summary/SafeTxHashDataRow'
+import TxDetailsRow from './TxDetailsRow'
+import NameChip from './NameChip'
+import { JsonView } from './JsonView'
+import { useBermuda } from '@/contexts/bermuda-context'
+import { Contract, ZeroAddress, formatUnits, isAddress } from 'ethers'
+import { type SafeStxHashParams } from '@/services/bermuda/types'
+
+type ShieldedReceiptProps = {
+  safeTxData: SafeTransaction['data']
+  shieldedTxData: SafeStxHashParams
+  txData?: TransactionData
+  txInfo?: TransactionDetails['txInfo']
+  grid?: boolean
+}
+
+const ScrollWrapper = ({ children }: { children: ReactElement | ReactElement[] }) => (
+  <Box sx={{ maxHeight: '550px', flex: 1, overflowY: 'auto', px: 2, pt: 1, mt: '0 !important' }}>{children}</Box>
+)
+
+export const ShieldedReceipt = ({ safeTxData, shieldedTxData, txData, txInfo, grid }: ShieldedReceiptProps) => {
+  const { sdk } = useBermuda()
+  const safeTxHash = useSafeTxHash({ safeTxData })
+  const domainHash = useDomainHash()
+  const messageHash = useMessageHash({ safeTxData })
+  const [stxHash, setStxHash] = useState<string | undefined>()
+  const [decimals, setDecimals] = useState<number | undefined>()
+  const [recipient, setRecipient] = useState<string | undefined>()
+  const [poolAddress, setPoolAddress] = useState<string | undefined>()
+
+  useEffect(() => {
+    async function run() {
+      const poolAddress = await sdk.config.pool.getAddress()
+      setPoolAddress(poolAddress)
+
+      const hash = sdk.safe.stxHash(shieldedTxData)
+      setStxHash(hash)
+
+      const token = new Contract(
+        shieldedTxData.token,
+        ['function decimals() view returns (uint8)'],
+        { provider: sdk.config.provider }
+      )
+
+      setDecimals(await token.decimals())
+
+      // If the recipient is the zero address, then we're dealing with a
+      // shielded deposit or shielded transfer.
+      if (shieldedTxData.recipient.toLowerCase() === ZeroAddress) {
+        const outputPubKey = shieldedTxData.outputPubkeys[0]
+
+        let prefix = sdk.utils.hex(outputPubKey, 32)
+        let address = prefix + '0'.repeat(64)
+
+        // Try to resolve shielded address (and potential name) via registry.
+        // If no result was found, then use the output pubkey padded with zeros.
+        let name = undefined
+        await sdk.registry.load()
+        const resolvedAddress = sdk.config.peers.find((peer: any) => peer.startsWith(prefix))!
+        if (resolvedAddress) {
+          address = resolvedAddress
+          name = await sdk.registry.nameOfShieldedAddress(resolvedAddress)
+        }
+
+        setRecipient(name?.length ? name : address)
+      } else {
+        setRecipient(shieldedTxData.recipient)
+      }
+    }
+
+    if (sdk && shieldedTxData) {
+      run()
+    }
+  }, [sdk, shieldedTxData])
+
+  // NOTE: The amount is the spending limit for deposits and withdrawals but for
+  // internal transfers it's the first output utxo which is the recipient's
+  // amount.
+  let amount = formatUnits(shieldedTxData.spendingLimit, decimals)
+  if (shieldedTxData.spendingLimit === 0n) {
+    amount = formatUnits(shieldedTxData.outputAmounts[0], decimals)
+  }
+
+  const ToWrapper = grid ? Box : Fragment
+
+  if (!poolAddress || !recipient || !stxHash) return <></>
+
+  return (
+    <PaperViewToggle activeView={0} leftAlign={grid}>
+      {[
+        {
+          title: 'Data',
+          content: (
+            <ScrollWrapper>
+              <Stack spacing={1} divider={<Divider />}>
+                <TxDetailsRow label="Target" grid={grid}>
+                  <ToWrapper>
+                    <NameChip txData={txData} txInfo={txInfo} />
+                    <Typography
+                      variant="body2"
+                      mt={grid ? 0.75 : 0}
+                      width={grid ? undefined : '100%'}
+                      sx={{
+                        '& *': { whiteSpace: 'normal', wordWrap: 'break-word', alignItems: 'flex-start !important' },
+                      }}
+                    >
+                      <EthHashInfo
+                        address={poolAddress}
+                        avatarSize={20}
+                        showPrefix={false}
+                        showName={true}
+                        shortAddress={false}
+                        hasExplorer
+                        showAvatar
+                        highlight4bytes
+                      />
+                    </Typography>
+                  </ToWrapper>
+                </TxDetailsRow>
+
+                <TxDetailsRow label="Token" grid={grid}>
+                  <Typography variant="body2">
+                    <EthHashInfo
+                      address={shieldedTxData.token}
+                      avatarSize={20}
+                      showPrefix={false}
+                      showName={false}
+                      shortAddress
+                      hasExplorer
+                    />
+                  </Typography>
+                </TxDetailsRow>
+
+                <TxDetailsRow label="Amount" grid={grid}>
+                  {amount}
+                </TxDetailsRow>
+
+                <TxDetailsRow label="Recipient" grid={grid}>
+                  <Typography variant="body2">
+                    <EthHashInfo
+                      address={recipient}
+                      avatarSize={20}
+                      showPrefix={false}
+                      shortAddress
+                      showName={true}
+                      hasExplorer={isAddress(recipient)}
+                    />
+                  </Typography>
+                </TxDetailsRow>
+              </Stack>
+            </ScrollWrapper>
+          ),
+        },
+        {
+          title: 'Hashes',
+          content: (
+            <ScrollWrapper>
+              <Stack spacing={1} divider={<Divider />}>
+                {stxHash && (
+                  <TxDetailsRow label="Shielded Transaction hash" grid={grid}>
+                    <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
+                      <HexEncodedData hexData={stxHash} limit={66} highlightFirstBytes={false} />
+                    </Typography>
+                  </TxDetailsRow>
+                )}
+
+                {domainHash && (
+                  <TxDetailsRow label="Domain hash" grid={grid}>
+                    <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
+                      <HexEncodedData hexData={domainHash} limit={66} highlightFirstBytes={false} />
+                    </Typography>
+                  </TxDetailsRow>
+                )}
+
+                {messageHash && (
+                  <TxDetailsRow label="Message hash" grid={grid}>
+                    <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
+                      <HexEncodedData hexData={messageHash} limit={66} highlightFirstBytes={false} />
+                    </Typography>
+                  </TxDetailsRow>
+                )}
+
+                {safeTxHash && (
+                  <TxDetailsRow label="safeTxHash" grid={grid}>
+                    <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
+                      <HexEncodedData hexData={safeTxHash} limit={66} highlightFirstBytes={false} />
+                    </Typography>
+                  </TxDetailsRow>
+                )}
+              </Stack>
+            </ScrollWrapper>
+          ),
+        },
+        {
+          title: 'JSON',
+          content: (
+            <ScrollWrapper>
+              <JsonView data={safeTxData} />
+            </ScrollWrapper>
+          ),
+        },
+      ]}
+    </PaperViewToggle>
+  )
+}

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -2,7 +2,7 @@ import TxCard from '@/components/tx-flow/common/TxCard'
 import { Grid2 as Grid, Stack, StepIcon, Typography } from '@mui/material'
 import { Receipt } from './Receipt'
 import ExternalLink from '@/components/common/ExternalLink'
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import SignOrExecuteFormV2 from '../SignOrExecuteForm/SignOrExecuteFormV2'
 import type { SignOrExecuteProps } from '../SignOrExecuteForm/SignOrExecuteFormV2'
@@ -11,6 +11,10 @@ import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics'
 import useWallet from '@/hooks/wallets/useWallet'
 import { isHardwareWallet, isLedgerLive } from '@/utils/wallets'
+import { ShieldedReceipt } from './ShieldedReceipt'
+import { useBermuda } from '@/contexts/bermuda-context'
+import { getTxHash } from '@/services/bermuda/txMapper'
+import { type SafeStxHashParams } from '@/services/bermuda/types'
 
 const InfoSteps = [
   {
@@ -65,11 +69,24 @@ const HardwareWalletStep = [
 ]
 
 export const ConfirmTxDetails = (props: SignOrExecuteProps) => {
+  const { getStxPreimage } = useBermuda()
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const [txPreview] = useTxPreview(safeTx?.data)
   const wallet = useWallet()
   const showHashes = wallet ? isHardwareWallet(wallet) || isLedgerLive(wallet) : false
   const steps = showHashes ? HardwareWalletStep : InfoSteps
+  const [stxPreimage, setStxPreimage] = useState<SafeStxHashParams | undefined>()
+
+  useEffect(() => {
+    if (props.txId) {
+      async function run() {
+        const txHash = getTxHash(props.txId!)
+        const preimage = await getStxPreimage(txHash)
+        setStxPreimage(preimage)
+      }
+      run()
+    }
+  }, [props.txId, getStxPreimage])
 
   if (!safeTx) {
     return null
@@ -92,7 +109,16 @@ export const ConfirmTxDetails = (props: SignOrExecuteProps) => {
           </Stack>
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <Receipt safeTxData={safeTx.data} txData={txPreview?.txData} txInfo={txPreview?.txInfo} />
+          {stxPreimage ? (
+            <ShieldedReceipt
+              safeTxData={safeTx.data}
+              shieldedTxData={stxPreimage}
+              txData={txPreview?.txData}
+              txInfo={txPreview?.txInfo}
+            />
+          ) : (
+            <Receipt safeTxData={safeTx.data} txData={txPreview?.txData} txInfo={txPreview?.txInfo} />
+          )}
         </Grid>
       </Grid>
 

--- a/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
@@ -1,7 +1,7 @@
 import TxCard from '@/components/tx-flow/common/TxCard'
 import { Grid2 as Grid, Stack, StepIcon, Typography } from '@mui/material'
 import ExternalLink from '@/components/common/ExternalLink'
-import { type PropsWithChildren, useContext } from 'react'
+import { type PropsWithChildren, useContext, useEffect, useState } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import useTxPreview from '../confirmation-views/useTxPreview'
 import Track from '@/components/common/Track'
@@ -10,8 +10,12 @@ import useWallet from '@/hooks/wallets/useWallet'
 import { isHardwareWallet, isLedgerLive } from '@/utils/wallets'
 import { TxFlowStep } from '@/components/tx-flow/TxFlowStep'
 import { Receipt } from '../ConfirmTxDetails/Receipt'
+import { useBermuda } from '@/contexts/bermuda-context'
+import { ShieldedReceipt } from '../ConfirmTxDetails/ShieldedReceipt'
 import { Slot, SlotName } from '@/components/tx-flow/slots'
 import { Sign } from '@/components/tx-flow/actions/Sign'
+import { getTxHash } from '@/services/bermuda/txMapper'
+import { type SafeStxHashParams } from '@/services/bermuda/types'
 
 const InfoSteps = [
   {
@@ -65,12 +69,31 @@ const HardwareWalletStep = [
   InfoSteps[2],
 ]
 
-export const ConfirmTxReceipt = ({ children, onSubmit }: PropsWithChildren<{ onSubmit: () => void }>) => {
+export const ConfirmTxReceipt = ({ children, onSubmit, txId }: PropsWithChildren<{ onSubmit: () => void, txId?: string }>) => {
   const { safeTx } = useContext(SafeTxContext)
   const [txPreview] = useTxPreview(safeTx?.data)
   const wallet = useWallet()
+  const { stxInfo, getStxPreimage } = useBermuda()
   const showHashes = wallet ? isHardwareWallet(wallet) || isLedgerLive(wallet) : false
   const steps = showHashes ? HardwareWalletStep : InfoSteps
+  const [stxPreimage, setStxPreimage] = useState<SafeStxHashParams | undefined>()
+
+  useEffect(() => {
+    if (txId) {
+      async function run() {
+        const txHash = getTxHash(txId!)
+        const preimage = await getStxPreimage(txHash)
+        setStxPreimage(preimage)
+      }
+      run()
+    }
+  }, [txId, getStxPreimage])
+
+  // Try to use stx preimage data from chain or default to data in local storage.
+  // We default to local storage as this component is also used when someone
+  // initiates a shield, transfer or unshield and at that point in time there's
+  // no data about the stx available on-chain yet.
+  const shieldedTxData = stxPreimage ?? stxInfo?.data
 
   if (!safeTx) {
     return false
@@ -94,7 +117,16 @@ export const ConfirmTxReceipt = ({ children, onSubmit }: PropsWithChildren<{ onS
             </Stack>
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }}>
-            <Receipt safeTxData={safeTx?.data} txData={txPreview?.txData} txInfo={txPreview?.txInfo} />
+            {shieldedTxData ? (
+              <ShieldedReceipt
+                safeTxData={safeTx?.data}
+                shieldedTxData={shieldedTxData}
+                txData={txPreview?.txData}
+                txInfo={txPreview?.txInfo}
+              />
+            ) : (
+              <Receipt safeTxData={safeTx?.data} txData={txPreview?.txData} txInfo={txPreview?.txInfo} />
+            )}
           </Grid>
         </Grid>
 

--- a/apps/web/src/contexts/bermuda-context.tsx
+++ b/apps/web/src/contexts/bermuda-context.tsx
@@ -1,18 +1,25 @@
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { resolveStxPreimage } from '@/services/bermuda/utils'
 import { useBermudaSDK } from '@/hooks/bermudaSDK/useBermudaSDK'
-import { useState, useContext, createContext, type ReactNode, useEffect, Dispatch, SetStateAction } from 'react'
+import { type SafeStxHashParams } from '@/services/bermuda/types'
+import { useState, useContext, createContext, type ReactNode, useEffect, useCallback } from 'react'
 
 const KEYPAIRS_NAMESPACE = 'keypairs'
 const EXECUTIONS_NAMESPACE = 'executions'
 const MISCELLANEOUS_NAMESPACE = 'misc'
 
-const STX_TYPE_KEY = 'stx-type'
+const STX_INFO_KEY = 'stx-info'
 
 export enum STXType {
   Deposit,
   Transfer,
   Withdrawal,
-  Undefined
+  Undefined,
+}
+
+export type STXInfo = {
+  type: STXType
+  data: SafeStxHashParams
 }
 
 export function useBermuda() {
@@ -29,43 +36,102 @@ export function BermudaProvider(props: Props) {
   const sdk = useBermudaSDK()
   const { safeAddress } = useSafeInfo()
   const [keyPair, setKeyPair] = useState<any | undefined>()
-  const [stxType, setStxType] = useState<STXType | undefined>()
+  const [stxInfo, setStxInfo] = useState<STXInfo | undefined>()
 
-  useEffect(() => {
-    if (sdk) {
-      const key = STX_TYPE_KEY
-      const namespace = MISCELLANEOUS_NAMESPACE
+  const loadKeyPair = useCallback(() => {
+    const key = safeAddress.toLowerCase()
+    const namespace = KEYPAIRS_NAMESPACE
 
-      const result = sdk.storage.get({ namespace, key })
-
-      setStxType(result)
+    const deserializer = function (text: string) {
+      const parsed = JSON.parse(text)
+      return sdk.types.KeyPair.fromJSON(parsed)
     }
+
+    return sdk.storage.get({ namespace, key, deserializer })
+  }, [safeAddress, sdk])
+
+  const loadStxInfo = useCallback(() => {
+    const key = STX_INFO_KEY
+    const namespace = MISCELLANEOUS_NAMESPACE
+
+    const deserializer = function (text: string) {
+      const { type, data } = JSON.parse(text)
+
+      const amounts = data.amounts.map((item: string) => BigInt(item))
+      const inputNullifiers = data.inputNullifiers.map((item: string) => BigInt(item))
+      const outputAmounts = data.outputAmounts.map((item: string) => BigInt(item))
+      const outputPubkeys = data.outputPubkeys.map((item: string) => BigInt(item))
+      const spendingLimit = BigInt(data.spendingLimit)
+
+      const result: STXInfo = {
+        type,
+        data: {
+          ...data,
+          amounts,
+          inputNullifiers,
+          outputAmounts,
+          outputPubkeys,
+          spendingLimit,
+        },
+      }
+
+      return result
+    }
+
+    const result: STXInfo | undefined = sdk.storage.get({ namespace, key, deserializer })
+
+    return result
   }, [sdk])
 
   useEffect(() => {
     if (sdk && safeAddress) {
-      const key = safeAddress.toLowerCase()
-      const namespace = KEYPAIRS_NAMESPACE
+      const keyPairResult = loadKeyPair()
+      const stxInfoResult = loadStxInfo()
 
-      const deserializer = function (text: string) {
-        const parsed = JSON.parse(text)
-        return sdk.types.KeyPair.fromJSON(parsed)
-      }
-
-      const result = sdk.storage.get({ namespace, key, deserializer })
-
-      setKeyPair(result)
+      setKeyPair(keyPairResult)
+      setStxInfo(stxInfoResult)
     }
-  }, [sdk, safeAddress])
+  }, [sdk, safeAddress, loadKeyPair, loadStxInfo])
 
-  function saveStxType(type: STXType) {
-    const key = STX_TYPE_KEY
+  async function getStxPreimage(txHash: string) {
+    if (keyPair) {
+      return resolveStxPreimage(keyPair, txHash)
+    }
+    return undefined
+  }
+
+  function saveStxInfo(value: STXInfo | undefined) {
+    const key = STX_INFO_KEY
     const namespace = MISCELLANEOUS_NAMESPACE
-    const value = type
 
-    sdk.storage.set({ namespace, key, value })
+    const serializer = function (value: STXInfo) {
+      const { type, data } = value
 
-    setStxType(value)
+      const amounts = data.amounts.map((item) => String(item))
+      const inputNullifiers = data.inputNullifiers.map((item) => String(item))
+      const outputAmounts = data.outputAmounts.map((item) => String(item))
+      const outputPubkeys = data.outputPubkeys.map((item) => String(item))
+      const spendingLimit = String(data.spendingLimit)
+
+      return JSON.stringify({
+        type,
+        data: {
+          ...data,
+          amounts,
+          inputNullifiers,
+          outputAmounts,
+          outputPubkeys,
+          spendingLimit,
+        },
+      })
+    }
+
+    sdk.storage.set({ namespace, key, value, serializer })
+
+    // Load STX Info to ensure that the date is correctly typed.
+    const result = loadStxInfo()
+
+    setStxInfo(result)
   }
 
   function saveKeyPair(keyPair: any) {
@@ -107,7 +173,22 @@ export function BermudaProvider(props: Props) {
   }
 
   return (
-    <BermudaContext.Provider value={{ sdk, keyPair, safeAddress, saveKeyPair, deleteKeyPair, saveStxType, stxType, saveStxExecuted, isStxExecuted }}>
+    <BermudaContext.Provider
+      value={{
+        sdk,
+        keyPair,
+        safeAddress,
+        saveKeyPair,
+        loadKeyPair,
+        deleteKeyPair,
+        stxInfo,
+        saveStxInfo,
+        loadStxInfo,
+        saveStxExecuted,
+        isStxExecuted,
+        getStxPreimage,
+      }}
+    >
       {props.children}
     </BermudaContext.Provider>
   )
@@ -120,11 +201,14 @@ type BermudaContext = {
   keyPair: any | undefined
   safeAddress: string
   saveKeyPair: (keyPair: any) => void
+  loadKeyPair: () => any | undefined
   deleteKeyPair: () => void
-  stxType: STXType | undefined
-  saveStxType: (value: STXType) => void
+  stxInfo: STXInfo | undefined
+  saveStxInfo: (value: STXInfo | undefined) => void
+  loadStxInfo: () => STXInfo | undefined
   saveStxExecuted: (id: string) => void
   isStxExecuted(id: string): boolean
+  getStxPreimage(txHash: string): Promise<SafeStxHashParams | undefined>
 }
 
 type Props = {

--- a/apps/web/src/hooks/loadables/useLoadTxQueue.ts
+++ b/apps/web/src/hooks/loadables/useLoadTxQueue.ts
@@ -16,7 +16,7 @@ export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
   const { chainId, txQueuedTag, txHistoryTag } = safe
   const [updatedTxId, setUpdatedTxId] = useState<string>('')
   const bermudaSDK = useBermudaSDK()
-  const { isStxExecuted, stxType } = useBermuda()
+  const { isStxExecuted, stxInfo } = useBermuda()
   const wallet = useWallet()
   // N.B. we reload when txQueuedTag/txHistoryTag/updatedTxId changes as txQueuedTag alone is not enough
   const reloadTag = (txQueuedTag ?? '') + (txHistoryTag ?? '') + updatedTxId
@@ -37,7 +37,7 @@ export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
         logoUri: address.logoUri ?? undefined,
       }))
 
-      const latestStxType = stxType ?? STXType.Undefined
+      const latestStxType = stxInfo?.type ?? STXType.Undefined
 
       return bermudaSDK.safe.listTxs(safeAddress, owner).then((result: unknown) => {
         const { all, pending } = result as SdkListTxsResult

--- a/apps/web/src/on-chain-data/hooks/useLoadTransactionDetails.ts
+++ b/apps/web/src/on-chain-data/hooks/useLoadTransactionDetails.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import loadSafeInfo from '../load-safe-info'
 import { useBermuda } from '@/contexts/bermuda-context'
-import { toTransactionDetails } from '@/services/bermuda/txMapper'
+import { getTxHash, toTransactionDetails } from '@/services/bermuda/txMapper'
 import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 
 export default function useLoadTransactionDetails(chainId: number, address: string, transactionId?: string) {
@@ -16,11 +16,7 @@ export default function useLoadTransactionDetails(chainId: number, address: stri
     try {
       const { owners, threshold } = await loadSafeInfo(chainId, address)
 
-      let txHash = transactionId
-      if (txHash.startsWith('multisig')) {
-        txHash = transactionId.split('_').pop()!
-      }
-
+      const txHash = getTxHash(transactionId)
       const { all } = await sdk.safe.listTxs(address)
       const transaction = all.find((item: any) => item.hash.toLowerCase() === txHash.toLowerCase())
 

--- a/apps/web/src/services/bermuda/buildShieldedDeposit.ts
+++ b/apps/web/src/services/bermuda/buildShieldedDeposit.ts
@@ -1,11 +1,12 @@
 import { getBermudaSDK } from '@/hooks/bermudaSDK/useBermudaSDK'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
-import type { MetaTransactionData } from '@safe-global/types-kit'
+import { type MetaTransactionData } from '@safe-global/types-kit'
 import { safeParseUnits } from '@safe-global/utils/utils/formatters'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { Interface } from 'ethers'
-import { OperationType } from '@safe-global/types-kit'
 import type { BatchSafeTx } from '@/services/tx/tx-sender/dispatch'
+import { getTransactAbis, simpleEncodeStx } from './utils'
+import { type SafeStxHashParams } from './types'
 
 type BuildShieldedDepositArgs = {
   safeAddress: string
@@ -23,7 +24,7 @@ export const buildShieldedDepositMetaTxs = async ({
   tokenDecimals,
   amount,
   shieldedKeyPair,
-}: BuildShieldedDepositArgs): Promise<{ metaTxs: MetaTransactionData[]; batchSafeTxs: BatchSafeTx[]; viewingKey?: string }> => {
+}: BuildShieldedDepositArgs): Promise<{ metaTxs: MetaTransactionData[]; batchSafeTxs: BatchSafeTx[]; shieldedTx: SafeStxHashParams; viewingKey?: string }> => {
   console.info('[ShieldAssets][Builder] Preparing shielded deposit meta txs', {
     safeAddress,
     shieldedAddress,
@@ -101,25 +102,8 @@ export const buildShieldedDepositMetaTxs = async ({
     safe: safeAddress,
   })
 
-  const { args, extData, viewingKey } = await bermudaSDK.core.prepareTransact({
-    inputs: [bogus1, bogus2],
-    outputs: [utxo, bogus3],
-    token: normalizedToken,
-    funder: safeAddress,
-    fee: 0n,
-  })
-  console.info('[ShieldAssets][Builder] Prepared transact payload', {
-    hasViewingKey: Boolean(viewingKey),
-  })
-
-  const [mappedArgs, mappedExtData] = bermudaSDK.utils.mapTransactArgs([args, extData])
-
-  const TRANSACT_SIMPLE_SIGNATURE =
-    'transact((bytes,bytes32[],bytes32,bytes32[],bytes32[],uint256,bytes32,bytes,bytes32[],bytes32,uint256,bytes32),(address,int256,address,uint256,bytes[],bool,address,uint256,bytes32,address))'
-  const transactData = poolContract.interface.encodeFunctionData(TRANSACT_SIMPLE_SIGNATURE, [
-    mappedArgs,
-    mappedExtData,
-  ])
+  const inputs = [bogus1, bogus2]
+  const outputs = [utxo, bogus3]
 
   const metaTxs: MetaTransactionData[] = []
 
@@ -135,18 +119,62 @@ export const buildShieldedDepositMetaTxs = async ({
     console.info('[ShieldAssets][Builder] Added ERC20 approval meta tx')
   }
 
+  const { args, extData } = await bermudaSDK.core.prepareTransact({
+    inputs: [bogus1, bogus2],
+    outputs: [utxo, bogus3],
+    token: normalizedToken,
+    funder: safeAddress,
+    fee: 0n,
+  })
+
+  const [_args, _extData] = bermudaSDK.utils.mapTransactArgs([args, extData])
+
+  const abi = getTransactAbis().find((abi: any) => abi.inputs.length === 2)
+  const data = bermudaSDK.config.pool.interface.encodeFunctionData(
+    new Interface([abi]).getFunction('transact'),
+    [_args, _extData],
+  )
+
   metaTxs.push({
     to: poolAddress,
-    data: transactData,
+    data,
     value: isNativeToken ? parsedAmount.toString() : '0',
   })
+
+  const ownPubKey = BigInt(shieldedKeyPair.address().slice(0, 66))
+  const stx: SafeStxHashParams = {
+    token: normalizedToken,
+    safe: safeAddress,
+    inputNullifiers: inputs.map((u: any) => u.getNullifier()),
+    amounts: outputs.map((u: any) => u.amount),
+    spendingLimit: parsedAmount,
+    recipient: safeAddress,
+    outputPubkeys: [ownPubKey, ownPubKey],
+    outputAmounts: [parsedAmount, 0n],
+  }
 
   console.info('[ShieldAssets][Builder] Prepared final meta tx bundle', {
     metaTxCount: metaTxs.length,
     includesApproval: !isNativeToken,
   })
 
-  const batchSafeTxs: BatchSafeTx[] = []
+  const encodedStx = simpleEncodeStx(stx)
+  const encryptionKey = shieldedKeyPair.x25519.secretKey
+  const encryptedStx = bermudaSDK.utils.encryptMessageCiphertext(encryptionKey, encodedStx).payload
+  const topic = bermudaSDK.utils.calcMessageCiphertextTopic({
+    chainId: bermudaSDK.config.chainId,
+    safeAddress,
+    secretKey: encryptionKey
+  })
 
-  return { metaTxs, batchSafeTxs, viewingKey }
+  await bermudaSDK.utils.relay(bermudaSDK.config.relayer, {
+    chainId: bermudaSDK.config.chainId,
+    target: bermudaSDK.config.signMsgHashLib,
+    data: Interface.from(bermudaSDK.abis.SIGN_MESSAGE_HASH_LIB_ABI).encodeFunctionData('messageCiphertext', [
+      topic,
+      encryptedStx
+    ]),
+  })
+
+  return { metaTxs, batchSafeTxs: [], shieldedTx: stx, viewingKey: undefined }
 }

--- a/apps/web/src/services/bermuda/buildShieldedTransfer.ts
+++ b/apps/web/src/services/bermuda/buildShieldedTransfer.ts
@@ -5,6 +5,7 @@ import { Interface, toUtf8Bytes, ZeroAddress } from 'ethers'
 import { OperationType } from '@safe-global/types-kit'
 import type { BatchSafeTx } from '@/services/tx/tx-sender/dispatch'
 import { simpleEncodeStx } from './utils'
+import { type SafeStxHashParams } from './types'
 
 type BuildShieldedTransferArgs = {
     safeAddress: string
@@ -22,7 +23,7 @@ export const buildShieldedTransferMetaTxs = async ({
     tokenDecimals,
     amount,
     shieldedKeyPair,
-}: BuildShieldedTransferArgs): Promise<{ metaTxs: MetaTransactionData[]; batchSafeTxs: BatchSafeTx[]; viewingKey?: string }> => {
+}: BuildShieldedTransferArgs): Promise<{ metaTxs: MetaTransactionData[]; batchSafeTxs: BatchSafeTx[]; shieldedTx: SafeStxHashParams; viewingKey?: string }> => {
     console.info('[ShieldedAssetTransfer][Builder] Preparing shielded transfer meta txs', {
         safeAddress,
         shieldedAddress,
@@ -87,7 +88,7 @@ export const buildShieldedTransferMetaTxs = async ({
     const ownAmount = sumIns - parsedAmount
     const safeToExternal = sumIns - (otherAmount + ownAmount)
     const spendingLimit = safeToExternal > 0n ? safeToExternal : 0n
-    const stx = {
+    const stx: SafeStxHashParams = {
         token: tokenAddress,
         safe: safeAddress,
         inputNullifiers: utxos.map((u: any) => u.getNullifier()),
@@ -127,5 +128,5 @@ export const buildShieldedTransferMetaTxs = async ({
         value: '0'
     }
 
-    return { metaTxs: [safeTx], batchSafeTxs: [], viewingKey: undefined }
+    return { metaTxs: [safeTx], batchSafeTxs: [], shieldedTx: stx, viewingKey: undefined }
 }

--- a/apps/web/src/services/bermuda/buildShieldedWithdrawal.ts
+++ b/apps/web/src/services/bermuda/buildShieldedWithdrawal.ts
@@ -5,6 +5,7 @@ import { Interface, toUtf8Bytes, ZeroAddress } from 'ethers'
 import { OperationType } from '@safe-global/types-kit'
 import type { BatchSafeTx } from '@/services/tx/tx-sender/dispatch'
 import { simpleEncodeStx } from './utils'
+import { type SafeStxHashParams } from './types'
 
 type BuildShieldedWithdrawalArgs = {
     safeAddress: string
@@ -24,7 +25,7 @@ export const buildShieldedWithdrawalMetaTxs = async ({
     tokenDecimals,
     amount,
     shieldedKeyPair,
-}: BuildShieldedWithdrawalArgs): Promise<{ metaTxs: MetaTransactionData[]; batchSafeTxs: BatchSafeTx[]; viewingKey?: string }> => {
+}: BuildShieldedWithdrawalArgs): Promise<{ metaTxs: MetaTransactionData[]; batchSafeTxs: BatchSafeTx[]; shieldedTx: SafeStxHashParams; viewingKey?: string }> => {
     console.info('[ShieldedAssetWithdrawal][Builder] Preparing shielded withdrawal meta txs', {
         safeAddress,
         nativeAddress,
@@ -87,7 +88,7 @@ export const buildShieldedWithdrawalMetaTxs = async ({
     const ownPubKey = BigInt(shieldedKeyPair.address().slice(0, 66))
     // const otherAmount = parsedAmount
     const ownAmount = sumIns - parsedAmount
-    const stx = {
+    const stx: SafeStxHashParams = {
         token: tokenAddress,
         safe: safeAddress,
         inputNullifiers: utxos.map((u: any) => u.getNullifier()),
@@ -129,5 +130,5 @@ export const buildShieldedWithdrawalMetaTxs = async ({
         value: '0'
     }
 
-    return { metaTxs: [safeTx], batchSafeTxs: [], viewingKey: undefined }
+    return { metaTxs: [safeTx], batchSafeTxs: [], shieldedTx: stx, viewingKey: undefined }
 }

--- a/apps/web/src/services/bermuda/dispatchShieldedTransfer.ts
+++ b/apps/web/src/services/bermuda/dispatchShieldedTransfer.ts
@@ -1,53 +1,12 @@
-import { TransactionSummary } from "@safe-global/safe-gateway-typescript-sdk";
-import { queryFilterBatched, shieldedAddressFromSpendingPubkey, simpleDecodeStx } from "./utils";
-import { Contract, getBytes, ZeroHash } from "ethers";
+import { Interface, ZeroHash } from "ethers";
 import { getBermudaSDK } from "@/hooks/bermudaSDK/useBermudaSDK";
+import { getTransactAbis, resolveStxPreimage, shieldedAddressFromSpendingPubkey } from "./utils";
+import { type TransactionSummary } from "@safe-global/safe-gateway-typescript-sdk";
 
 export async function dispatchShieldedTransfer(shieldedKeyPair: any, safeAddress: string, txSummary: TransactionSummary) {
-    // const { safeAddress } = useSafeInfo()
     const bermudaSDK = getBermudaSDK()
 
-    // List all MessageCiphertext events, try decrypt, then decode, then stxhash
-    // If the resulting stxhash is included in txSummary.data (SignMsgHash data) 
-    // its most likely the preimage corresponding to the stx hash that got 
-    // "signed" thru the multisig 
-    console.log("$$$$$ txSummary.txHash", txSummary.txHash)
-    const signMsgHashTx = await bermudaSDK.config.provider.getTransaction(txSummary.txHash)
-    if (!signMsgHashTx) throw Error("Cannot find SignMsgHashLib tx")
-
-    const encryptionKey = shieldedKeyPair.x25519.secretKey
-    const topic = bermudaSDK.utils.calcMessageCiphertextTopic({
-        chainId: bermudaSDK.config.chainId,
-        safeAddress,
-        secretKey: encryptionKey
-    })
-
-    const toBlock = await bermudaSDK.config.provider.getBlockNumber()
-    const signMsgHashLib = new Contract(
-        bermudaSDK.config.signMsgHashLib,
-        bermudaSDK.abis.SIGN_MESSAGE_HASH_LIB_ABI,
-        { provider: bermudaSDK.config.provider }
-    )
-
-    const ciphertexts = await queryFilterBatched(
-        0n,
-        toBlock,
-        signMsgHashLib,
-        // indexing by topic returns an empty result
-        signMsgHashLib.filters.MessageCiphertext(null/*topic*/, null)
-    )
-        .then(events => events.map(e => e.args.ciphertext))
-    console.log("ciphertexts", ciphertexts)
-    let stx
-    for (const c of ciphertexts) {
-        const plaintext = bermudaSDK.utils.decryptMessageCiphertext(encryptionKey, getBytes(c))
-        const decoded = simpleDecodeStx(plaintext)
-        const stxHash = bermudaSDK.safe.stxHash(decoded)
-        if (signMsgHashTx.data.includes(stxHash.slice(2))) {
-            stx = decoded
-            break
-        }
-    }
+    const stx = await resolveStxPreimage(shieldedKeyPair, txSummary.txHash!)
     if (!stx) throw Error("Cannot find stx hash preimage")
 
     const utxos = await bermudaSDK.utils
@@ -74,8 +33,8 @@ export async function dispatchShieldedTransfer(shieldedKeyPair: any, safeAddress
     }
 
     //NOTE We load all registered peers from tehe regsitry here once
-    // so that all subsequent shieldedAddressFromSpendingPubkey() invocations 
-    // have the fresh registry available. sdk.registry.load() internally 
+    // so that all subsequent shieldedAddressFromSpendingPubkey() invocations
+    // have the fresh registry available. sdk.registry.load() internally
     // concats loaded shielded addresses to sdk.config.peers
     await bermudaSDK.registry.load()
 
@@ -124,8 +83,10 @@ export async function dispatchShieldedTransfer(shieldedKeyPair: any, safeAddress
 
     const [_args, _extData] = bermudaSDK.utils.mapTransactArgs([args, extData])
     const target = await bermudaSDK.config.pool.getAddress()
+
+    const abi = getTransactAbis().find((abi: any) => abi.inputs.length === 2)
     const data = bermudaSDK.config.pool.interface.encodeFunctionData(
-        'transact((bytes,bytes32[],bytes32,bytes32[],bytes32[],uint256,bytes32,bytes,bytes32[],bytes32,uint256,bytes32),(address,int256,address,uint256,bytes[],bool,address,uint256,bytes32,address),(uint256,uint8,bytes32,bytes32))',
+        new Interface([abi]).getFunction('transact'),
         [
             _args,
             _extData,
@@ -133,7 +94,7 @@ export async function dispatchShieldedTransfer(shieldedKeyPair: any, safeAddress
         ]
     )
 
-    bermudaSDK.utils.relay(bermudaSDK.config.relayer, {
+    return bermudaSDK.utils.relay(bermudaSDK.config.relayer, {
         chainId: bermudaSDK.config.chainId,
         target,
         data

--- a/apps/web/src/services/bermuda/dispatchShieldedWithdrawal.ts
+++ b/apps/web/src/services/bermuda/dispatchShieldedWithdrawal.ts
@@ -1,55 +1,12 @@
-import { TransactionSummary } from "@safe-global/safe-gateway-typescript-sdk";
-import { queryFilterBatched, shieldedAddressFromSpendingPubkey, simpleDecodeStx } from "./utils";
-import { Contract, getBytes, ZeroHash } from "ethers";
+import { Interface, ZeroHash } from "ethers";
+import { getTransactAbis, resolveStxPreimage } from "./utils";
 import { getBermudaSDK } from "@/hooks/bermudaSDK/useBermudaSDK";
+import { type TransactionSummary } from "@safe-global/safe-gateway-typescript-sdk";
 
 export async function dispatchShieldedWithdrawal(shieldedKeyPair: any, safeAddress: string, txSummary: TransactionSummary) {
-    // const { safeAddress } = useSafeInfo()
     const bermudaSDK = getBermudaSDK()
 
-    // List all MessageCiphertext events, try decrypt, then decode, then stxhash
-    // If the resulting stxhash is included in txSummary.data (SignMsgHash data) 
-    // its most likely the preimage corresponding to the stx hash that got 
-    // "signed" thru the multisig 
-    console.log("$$$$$ txSummary.txHash", txSummary.txHash)
-    const signMsgHashTx = await bermudaSDK.config.provider.getTransaction(txSummary.txHash)
-    if (!signMsgHashTx) throw Error("Cannot find SignMsgHashLib tx")
-
-    const encryptionKey = shieldedKeyPair.x25519.secretKey
-    const topic = bermudaSDK.utils.calcMessageCiphertextTopic({
-        chainId: bermudaSDK.config.chainId,
-        safeAddress,
-        secretKey: encryptionKey
-    })
-
-    const toBlock = await bermudaSDK.config.provider.getBlockNumber()
-    const signMsgHashLib = new Contract(
-        bermudaSDK.config.signMsgHashLib,
-        bermudaSDK.abis.SIGN_MESSAGE_HASH_LIB_ABI,
-        { provider: bermudaSDK.config.provider }
-    )
-
-    const ciphertexts = await queryFilterBatched(
-        0n,
-        toBlock,
-        signMsgHashLib,
-        // indexing by topic returns an empty result
-        signMsgHashLib.filters.MessageCiphertext(null/*topic*/, null)
-    )
-        .then(events => events.map(e => e.args.ciphertext))
-    console.log("ciphertexts", ciphertexts)
-    let stx
-    for (const c of ciphertexts) {
-        const plaintext = bermudaSDK.utils.decryptMessageCiphertext(encryptionKey, getBytes(c))
-        const decoded = simpleDecodeStx(plaintext)
-        console.log("$$$$$$ dispatchShieldedWithdrawal found stx preimage", decoded)
-        const stxHash = bermudaSDK.safe.stxHash(decoded)
-        console.log("$$$$$$$$$ dispatchShieldedWithdrawal stxHash", stxHash)
-        if (signMsgHashTx.data.includes(stxHash.slice(2))) {
-            stx = decoded
-            break
-        }
-    }
+    const stx = await resolveStxPreimage(shieldedKeyPair, txSummary.txHash!)
     if (!stx) throw Error("Cannot find stx hash preimage")
 
     const utxos = await bermudaSDK.utils
@@ -76,8 +33,8 @@ export async function dispatchShieldedWithdrawal(shieldedKeyPair: any, safeAddre
     }
 
     //NOTE We load all registered peers from tehe regsitry here once
-    // so that all subsequent shieldedAddressFromSpendingPubkey() invocations 
-    // have the fresh registry available. sdk.registry.load() internally 
+    // so that all subsequent shieldedAddressFromSpendingPubkey() invocations
+    // have the fresh registry available. sdk.registry.load() internally
     // concats loaded shielded addresses to sdk.config.peers
     await bermudaSDK.registry.load()
 
@@ -133,9 +90,10 @@ export async function dispatchShieldedWithdrawal(shieldedKeyPair: any, safeAddre
 
     const [_args, _extData] = bermudaSDK.utils.mapTransactArgs([args, extData])
     const target = await bermudaSDK.config.pool.getAddress()
-    const data = bermudaSDK.config.pool.interface.encodeFunctionData(
-        'transact((bytes,bytes32[],bytes32,bytes32[],bytes32[],uint256,bytes32,bytes,bytes32[],bytes32,uint256,bytes32),(address,int256,address,uint256,bytes[],bool,address,uint256,bytes32,address),(uint256,uint8,bytes32,bytes32))',
 
+    const abi = getTransactAbis().find((abi: any) => abi.inputs.length === 2)
+    const data = bermudaSDK.config.pool.interface.encodeFunctionData(
+        new Interface([abi]).getFunction('transact'),
         [
             _args,
             _extData,
@@ -143,7 +101,7 @@ export async function dispatchShieldedWithdrawal(shieldedKeyPair: any, safeAddre
         ]
     )
 
-    bermudaSDK.utils.relay(bermudaSDK.config.relayer, {
+    return bermudaSDK.utils.relay(bermudaSDK.config.relayer, {
         chainId: bermudaSDK.config.chainId,
         target,
         data

--- a/apps/web/src/services/bermuda/txMapper.ts
+++ b/apps/web/src/services/bermuda/txMapper.ts
@@ -20,8 +20,18 @@ type MapArgs = {
   threshold: number
 }
 
+export function getTxHash(txId: string) {
+  let txHash = txId
+
+  if (txHash.startsWith('multisig')) {
+    txHash = txId.split('_')[2]
+  }
+
+  return txHash
+}
+
 const buildTxId = (safeAddress: string, info: SdkSafeTxInfo): string => {
-  return `multisig_${safeAddress.toLowerCase()}_${info.hash}`
+  return `multisig_${safeAddress.toLowerCase()}_${info.txHash}_${info.hash}`
 }
 
 const getStatus = (info: SdkSafeTxInfo, threshold: number) => {
@@ -179,7 +189,7 @@ export const mapSdkQueueToTransactionPage = ({ safeAddress, allTxs, owners, thre
           gasPrice: '0',
           gasToken: ZeroAddress,
           refundReceiver: ZeroAddress,
-          // "Inheriting" the nonce here to display a grouped tx for the 
+          // "Inheriting" the nonce here to display a grouped tx for the
           // mutlisig auth and shielded exec bundle
           nonce: allTxs[i].details.nonce
         },
@@ -187,7 +197,7 @@ export const mapSdkQueueToTransactionPage = ({ safeAddress, allTxs, owners, thre
         signatures: allTxs[i].signatures,
         executed: false,
         stxExecuted,
-        // "Inheriting" the txHash here to display a grouped tx for the 
+        // "Inheriting" the txHash here to display a grouped tx for the
         // mutlisig auth and shielded exec bundle
         txHash: allTxs[i].txHash
       })

--- a/apps/web/src/services/bermuda/utils.ts
+++ b/apps/web/src/services/bermuda/utils.ts
@@ -1,6 +1,26 @@
+import { ethers } from 'ethers'
+import { type SafeStxHashParams } from './types'
 import { getBermudaSDK } from '@/hooks/bermudaSDK/useBermudaSDK'
-import { getBytes, hexlify, toBeHex, toUtf8Bytes, toUtf8String } from 'ethers'
-import { SafeStxHashParams } from './types'
+import { Contract, getBytes, toBeHex, toUtf8Bytes, toUtf8String } from 'ethers'
+import { decodeMultiSendData } from '@safe-global/protocol-kit/dist/src/utils/transactions/utils'
+
+export function getTransactAbis() {
+  const sdk = getBermudaSDK()
+  if (!sdk) {
+    throw new Error('Bermuda SDK not initialized')
+  }
+
+  return sdk.abis.POOL_ABI.filter((item: any) => {
+    if (
+      item.type === "function" &&
+      item.name === "transact" &&
+      item.outputs.length === 0 &&
+      item.stateMutability === "payable"
+    ) {
+      return item
+    }
+  })
+}
 
 export async function getShieldedBalance(shieldedKeyPair: any, token: string): Promise<bigint> {
   token = token.toLowerCase()
@@ -35,7 +55,6 @@ export async function queryFilterBatched(
   let i = fromBlock
   let batchToBlock
   const currentBlockNumber = await contract.runner.provider.getBlockNumber()
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     batchToBlock = i + batchSize
     if (batchToBlock > currentBlockNumber) {
@@ -82,3 +101,151 @@ export function shieldedAddressFromSpendingPubkey(outputPubkey: bigint, shielded
   if (!shieldedAdrs) throw Error('Cannot resolve shielded address')
   return shieldedAdrs
 }
+
+export async function resolveStxPreimage(keyPair: any, txHash: string) {
+  const sdk = getBermudaSDK()
+  if (!sdk) {
+    throw new Error('Bermuda SDK not initialized')
+  }
+
+  // Get the transaction data from the `ProposeTxLib` call which potentially
+  // includes the `stxHash` or `transact` function call arguments (which can be
+  // set indirectly via a `MultiSend` call).
+  // Then list all `MessageCiphertext` events and for each individual ciphertext
+  // first try to decrypt it and check if the `stxHash` is included in the
+  // aforementioned transaction data. Otherwise try to extract the function call
+  // arguments from the transaction data (that can be part of a `MultiSend`
+  // call) to reconstruct the stx preimage which can then be hashed to recompute
+  // the `stxHash` which we then check against.
+  const proposeTxLibTx = await sdk.config.provider.getTransaction(txHash)
+  if (!proposeTxLibTx) {
+    return undefined
+  }
+
+  const encryptionKey = keyPair.x25519.secretKey
+  const publicKey = BigInt(keyPair.address().slice(0, 66))
+  const signMsgHashLib = new Contract(
+    sdk.config.signMsgHashLib,
+    sdk.abis.SIGN_MESSAGE_HASH_LIB_ABI,
+    { provider: sdk.config.provider }
+  )
+
+  const fromBlock = 0n
+  const toBlock = await sdk.config.provider.getBlockNumber()
+
+  const events = await queryFilterBatched(
+    fromBlock,
+    toBlock,
+    signMsgHashLib,
+    signMsgHashLib.filters.MessageCiphertext(null, null),
+  )
+
+  const rawProposeData = proposeTxLibTx.data
+  const proposeTxLibAbi = sdk.abis.PROPOSE_TX_LIB_ABI
+  const proposeTxLibInterface = new ethers.Interface(proposeTxLibAbi)
+  const parsedProposeData = proposeTxLibInterface.parseTransaction({ data: rawProposeData })
+
+  const poolAbi = sdk.abis.POOL_ABI
+  const poolInterface = new ethers.Interface(poolAbi)
+  const poolAddress = (await sdk.config.pool.getAddress()).toLowerCase()
+
+  const multiSendAddress = sdk.config.multiSend.toLowerCase()
+  const multiSendCallOnlyAddress = sdk.config.multiSendCallOnly.toLowerCase()
+
+  const ciphertexts = events.map((event) => event.args.ciphertext)
+
+  // This function extracts the stx preimage from a Pool transaction that
+  // contains the data of a `transact` function invocation.
+  function recomputeStxPreimage(transactTxData: string) {
+    const parsedTransactData = poolInterface.parseTransaction({ data: transactTxData })
+
+    const args = parsedTransactData!.args[0]
+    const inputNullifiers = args[3]
+
+    const extData = parsedTransactData!.args[1]
+    const encryptedOutput1 = extData[4][0]
+    const encryptedOutput2 = extData[4][1]
+    const token = extData[6]
+    const funder = extData[9]
+
+    const { utxo: output1 } = sdk.types.Utxo.decrypt(keyPair, [], encryptedOutput1)
+    const { utxo: output2 } = sdk.types.Utxo.decrypt(keyPair, [], encryptedOutput2)
+
+    const outputs = [output1, output2]
+    const amount = sdk.utils.sumAmounts(outputs)
+
+    const stx: SafeStxHashParams = {
+      token,
+      safe: funder,
+      inputNullifiers: inputNullifiers.map(BigInt),
+      amounts: [output1.amount, output2.amount],
+      recipient: funder,
+      outputPubkeys: [publicKey, publicKey],
+      outputAmounts: [output1.amount, output2.amount],
+      spendingLimit: amount
+    }
+
+    return stx
+  }
+
+  let stx = undefined
+  for (const ciphertext of ciphertexts) {
+    const plaintext = sdk.utils.decryptMessageCiphertext(encryptionKey, getBytes(ciphertext))
+    const stxDecoded = simpleDecodeStx(plaintext)
+    const stxHash = sdk.safe.stxHash(stxDecoded)
+
+    // 1st attempt: Try to find the `stxHash` in the `ProposeTxLib` transaction
+    // data.
+    if (rawProposeData.includes(stxHash.slice(2))) {
+      stx = stxDecoded
+      break
+    }
+
+    // 2nd attempt: Try to reconstruct stx hash based on `transact` function
+    // call arguments that were passed to `ProposeTxLib` and can therefore be
+    // found in its transaction data.
+    const isPoolRecipient = parsedProposeData &&
+      parsedProposeData.args[1][0].toLowerCase() === poolAddress
+
+    if (isPoolRecipient) {
+      const rawTransactData = parsedProposeData.args[1][2]
+      const stxRecomputed = recomputeStxPreimage(rawTransactData)
+
+      const hash = sdk.safe.stxHash(stxRecomputed)
+
+      if (hash === stxHash) {
+        stx = stxRecomputed
+        break
+      }
+    }
+
+    // 3rd attempt: Try to reconstruct stx hash based on `transact` function
+    // call arguments that were passed to `MultiSend` and are recorded in the
+    // call to `ProposeTxLib` and can therefore be found in its transaction data.
+    const isMultiSendRecipient = parsedProposeData &&
+      (parsedProposeData.args[1][0].toLowerCase() === multiSendAddress ||
+        parsedProposeData.args[1][0].toLowerCase() === multiSendCallOnlyAddress)
+
+    if (isMultiSendRecipient) {
+      const rawMultiSendData = parsedProposeData.args[1][2]
+
+      const transactions = decodeMultiSendData(rawMultiSendData)
+      const transaction = transactions.find(tx => tx.to.toLowerCase() === poolAddress)
+
+      if (transaction) {
+        const rawTransactData = transaction.data
+        const stxRecomputed = recomputeStxPreimage(rawTransactData)
+
+        const hash = sdk.safe.stxHash(stxRecomputed)
+
+        if (hash === stxHash) {
+          stx = stxRecomputed
+          break
+        }
+      }
+    }
+  }
+
+  return stx
+}
+


### PR DESCRIPTION
Adds a component which allows us to display specific information for shielded transactions.

Right now it's using dummy data, so we need to replace that with real data once that part is done (I left `TODO` comments in there to see where we need to update things).

Here's how it looks:

<img width="1260" height="612" alt="Screenshot 2025-11-07 at 3 51 14 PM" src="https://github.com/user-attachments/assets/5da1d2bb-b22d-471a-84f0-1cf10237786f" />
