### PR TITLE
feat: remove safe apps nav item

### DIFF
--- a/apps/web/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/config.tsx
@@ -74,7 +74,6 @@ export const settingsNavItems = [
   { label: 'Security', href: AppRoutes.settings.security },
   { label: 'Notifications', href: AppRoutes.settings.notifications },
   { label: 'Modules', href: AppRoutes.settings.modules },
-  { label: 'Safe Apps', href: AppRoutes.settings.safeApps.index },
   { label: 'Data', href: AppRoutes.settings.data },
   { label: 'Environment variables', href: AppRoutes.settings.environmentVariables },
 ]


### PR DESCRIPTION
Removes the "Safe Apps" tab in the settings navbar.

#18 