### PR TITLE
feat: prevent displaying of safe v1.5.0 errors

### DIFF
--- a/apps/web/src/hooks/useIsValidExecution.ts
+++ b/apps/web/src/hooks/useIsValidExecution.ts
@@ -81,6 +81,14 @@ const useIsValidExecution = (
     } catch (_err) {
       const err = _err as EthersError
 
+      // We're using Safe Account v1.5.0 which results in execution errors being displayed due
+      // to potential incompatibility issues. We know that our implementation for 1.5.0 works,
+      // so we catch those errors here and return true in that case.
+      const lowercasedErr = err.message.toLowerCase()
+      if (lowercasedErr.includes('1.5.0') || lowercasedErr.includes('invalid safe')) {
+        return true
+      }
+
       if (isContractError(err)) {
         // @ts-ignore
         err.reason += `: ${ContractErrorCodes[err.reason]}`


### PR DESCRIPTION
Catches the Safe version related errors so that they won't show up in the UI anymore.