### PR TITLE
fix: fix default token selection

### DIFF
--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateShieldedTokenTransfer.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateShieldedTokenTransfer.tsx
@@ -87,6 +87,10 @@ export const CreateShieldedTokenTransfer = ({ txNonce }: CreateTokenTransferProp
   const isMassPayoutsEnabled = useHasFeature(FEATURES.MASS_PAYOUTS)
   const { onNext, data } = useContext(TxFlowContext) as TxFlowContextType<MultiTokenTransferParams>
 
+  const wethAddress = (process.env.NEXT_PUBLIC_MOCK_WETH_ADDRESS ||
+    process.env.NEXT_PUBLIC_WETH_ADDRESS ||
+    process.env.NEXT_PUBLIC_WETH)!.toLowerCase()
+
   useEffect(() => {
     if (txNonce !== undefined) {
       setNonce(txNonce)
@@ -105,7 +109,9 @@ export const CreateShieldedTokenTransfer = ({ txNonce }: CreateTokenTransferProp
         data?.recipients.map(({ tokenAddress, ...rest }) => ({
           ...rest,
           [TokenTransferFields.tokenAddress]:
-            canCreateSpendingLimitTx && !canCreateStandardTx ? balancesItems[0]?.tokenInfo.address : tokenAddress,
+            canCreateSpendingLimitTx && !canCreateStandardTx ? balancesItems[0]?.tokenInfo.address : wethAddress,
+          [TokenTransferFields.shieldedTokenAddress]:
+            canCreateSpendingLimitTx && !canCreateStandardTx ? balancesItems[0]?.tokenInfo.address : wethAddress,
         })) || [],
     },
     mode: 'onChange',

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/ShieldedRecipientRow/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/ShieldedRecipientRow/index.tsx
@@ -1,5 +1,5 @@
 import AddressBookInput from '@/components/common/AddressBookInput'
-import TokenAmountInput from '@/components/common/TokenAmountInput'
+import ShieldedTokenAmountInput from '@/components/common/ShieldedTokenAmountInput'
 import { useShieldedBalances } from '@/hooks/useShieldedBalances'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import { Box, Button, FormControl, Stack, SvgIcon } from '@mui/material'
@@ -95,7 +95,7 @@ export const ShieldedRecipientRow = ({ fieldArray, removable = true, remove, dis
           </FormControl>
 
           <FormControl fullWidth>
-            <TokenAmountInput
+            <ShieldedTokenAmountInput
               fieldArray={fieldArray}
               balances={isSpendingLimitType ? spendingLimitBalances : balances.items}
               selectedToken={selectedToken}


### PR DESCRIPTION
Fixes the default token selector so when shielded transfers are performed as shielded transfers can only be done with ERC-20s like WETH and there's no ETH because of this.