### PR TITLE
fix: remove wip copy for transaction history tab

### DIFF
--- a/apps/web/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/config.tsx
@@ -41,7 +41,7 @@ export const navItems: NavItem[] = [
 
 export const transactionNavItems = [
   { label: 'Queue', href: AppRoutes.transactions.queue },
-  { label: 'History (WIP)', href: AppRoutes.transactions.history, disabled: true },
+  { label: 'History', href: AppRoutes.transactions.history, disabled: true },
   { label: 'Messages', href: AppRoutes.transactions.messages },
 ]
 


### PR DESCRIPTION
Trivial update of our queue history copy (removes the "WIP").