### PR TITLE
fix: don't set recipient in shielded transfer form

### DIFF
--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateShieldedTokenTransfer.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateShieldedTokenTransfer.tsx
@@ -108,6 +108,7 @@ export const CreateShieldedTokenTransfer = ({ txNonce }: CreateTokenTransferProp
       recipients:
         data?.recipients.map(({ tokenAddress, ...rest }) => ({
           ...rest,
+          recipient: '',
           [TokenTransferFields.tokenAddress]:
             canCreateSpendingLimitTx && !canCreateStandardTx ? balancesItems[0]?.tokenInfo.address : wethAddress,
           [TokenTransferFields.shieldedTokenAddress]:


### PR DESCRIPTION
Removes the auto-populating of the recipient's address in the shielded token transfer form.