### PR TITLE
fix: fix initializing of bermuda sdk

### DIFF
--- a/apps/web/src/hooks/bermudaSDK/useInitBermudaSDK.ts
+++ b/apps/web/src/hooks/bermudaSDK/useInitBermudaSDK.ts
@@ -27,28 +27,25 @@ export const useInitBermudaSDK = () => {
     }
 
     web3ReadOnly?.getNetwork().then(({ chainId }) => {
-
-      initBermudaSDK({ chainId: safe.chainId || chainId })
-        .then(setBermudaSDK)
-        .catch((_e) => {
-          const e = asError(_e)
-          dispatch(
-            showNotification({
-              message: 'Error initializing the Bermuda SDK. Please try reloading the page.',
-              groupKey: 'core-sdk-init-error',
-              variant: 'error',
-              detailedMessage: e.message,
-            }),
-          )
-          trackError(ErrorCodes._105, e.message)
-        })
-
+      // Only initialize the Bermuda SDK if the current network's chain id
+      // matches the chain id that's used by the safe. This ensures that we
+      // won't try to initialize the SDK for unknown chain ids.
+      if (String(chainId) === safe.chainId) {
+        return initBermudaSDK({ chainId })
+          .then(setBermudaSDK)
+          .catch((_e) => {
+            const e = asError(_e)
+            dispatch(
+              showNotification({
+                message: 'Error initializing the Bermuda SDK. Please try reloading the page.',
+                groupKey: 'core-sdk-init-error',
+                variant: 'error',
+                detailedMessage: e.message,
+              }),
+            )
+            trackError(ErrorCodes._105, e.message)
+          })
+      }
     })
-  }, [
-    address,
-    dispatch,
-    safe.chainId,
-    safeLoaded,
-    web3ReadOnly,
-  ])
+  }, [address, dispatch, safe.chainId, safeLoaded, web3ReadOnly, safe.address.value])
 }


### PR DESCRIPTION
Fixes the initialization logic of the Bermuda SDK.

Closes #67 

I debugged this and the `chainId` value that's returned by `web3ReadOnly?.getNetwork()` will be Sepolia's in the beginning before it switches to Anvil's. To mitigate this problem I added a check that ensures that the `chainId` returned by `web3ReadOnly?.getNetwork()` must be equal to the one used by the Safe which we get via `safe.chainId`. Given that our Safe's are deployed to Anvil, `safe.chainId` will be Anvil's. If both value are equal, only then do we initialize the SDK.