### PR TITLE
feat: automatically run stx finalization logic

### DIFF
--- a/apps/web/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/apps/web/src/components/transactions/ExecuteTxButton/index.tsx
@@ -1,9 +1,9 @@
 import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
 import useIsPending from '@/hooks/useIsPending'
 import type { SyntheticEvent } from 'react'
-import { type ReactElement, useContext, useEffect, useState } from 'react'
+import { type ReactElement, useContext } from 'react'
 import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
-import { Button, CircularProgress, Tooltip } from '@mui/material'
+import { Button, Tooltip } from '@mui/material'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
@@ -13,9 +13,6 @@ import { ReplaceTxHoverContext } from '../GroupedTxListItems/ReplaceTxHoverProvi
 import CheckWallet from '@/components/common/CheckWallet'
 import { TxModalContext } from '@/components/tx-flow'
 import { ConfirmTxFlow } from '@/components/tx-flow/flows'
-import { dispatchShieldedTransfer } from '@/services/bermuda/dispatchShieldedTransfer'
-import { STXType, useBermuda } from '@/contexts/bermuda-context'
-import { dispatchShieldedWithdrawal } from '@/services/bermuda/dispatchShieldedWithdrawal'
 
 const ExecuteTxButton = ({
   txSummary,
@@ -29,49 +26,11 @@ const ExecuteTxButton = ({
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
   const isPending = useIsPending(txSummary.id)
   const { setSelectedTxId } = useContext(ReplaceTxHoverContext)
-  const { keyPair, sdk, saveStxExecuted, isStxExecuted, stxType } = useBermuda()
-  const [isDispatchingProofs, setIsDispatchingProofs] = useState(false)
 
   const expiredSwap = useIsExpiredSwap(txSummary.txInfo)
 
-  const methodName = (txSummary.txInfo as any).methodName
-  const isStxTransferOrUnshield = methodName === "Shielded transfer" || methodName === "Unshield"
-
   const isNext = (txNonce !== undefined && txNonce === safe.nonce) //|| problyStx
-  const _isStxExecuted = sdk && isStxExecuted(txSummary.txHash!.toLowerCase())
-  const isDisabled = _isStxExecuted || isDispatchingProofs || !isStxTransferOrUnshield && (!isNext || !sdk || expiredSwap || isPending)
-
-  useEffect(() => {
-    (async () => {
-      if (isStxTransferOrUnshield) {
-        try {
-          setIsDispatchingProofs(true)
-
-          console.log("$$$$$ stxType", stxType, "stxType === STXType.Withdrawal", stxType === STXType.Withdrawal)
-          if (stxType === STXType.Transfer) {
-            await dispatchShieldedTransfer(keyPair, safe.address.value, txSummary)
-          } else if (stxType === STXType.Withdrawal) {
-            await dispatchShieldedWithdrawal(keyPair, safe.address.value, txSummary)
-          } else {
-            throw Error("Unexpected stx type " + stxType)
-          }
-
-          saveStxExecuted(txSummary.txHash!.toLowerCase())
-        } catch (err) {
-          console.error(err)
-        } finally {
-          setIsDispatchingProofs(false)
-        }
-      }
-    })()
-  }, [
-    keyPair,
-    stxType,
-    txSummary,
-    saveStxExecuted,
-    safe.address.value,
-    isStxTransferOrUnshield,
-  ])
+  const isDisabled = !isNext || expiredSwap || isPending
 
   const onClick = async (e: SyntheticEvent) => {
     e.stopPropagation()
@@ -92,7 +51,7 @@ const ExecuteTxButton = ({
     <>
       <CheckWallet allowNonOwner>
         {(isOk) => (
-          <Tooltip title={isOk && !isNext && !isStxTransferOrUnshield ? 'You must execute the transaction with the lowest nonce first' : ''}>
+          <Tooltip title={isOk && !isNext ? 'You must execute the transaction with the lowest nonce first' : ''}>
             <span>
               <Track {...TX_LIST_EVENTS.EXECUTE}>
                 <Button
@@ -104,7 +63,7 @@ const ExecuteTxButton = ({
                   size={compact ? 'small' : 'stretched'}
                   sx={{ minWidth: '106.5px', py: compact ? 0.8 : undefined, cursor: isDisabled ? 'default' : 'pointer' }}
                 >
-                  {isDispatchingProofs ? <CircularProgress color='primary' size='15px' thickness={5} /> : 'Execute'}
+                  Execute
                 </Button>
               </Track>
             </span>

--- a/apps/web/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/apps/web/src/components/transactions/ExecuteTxButton/index.tsx
@@ -41,33 +41,43 @@ const ExecuteTxButton = ({
   const _isStxExecuted = sdk && isStxExecuted(txSummary.txHash!.toLowerCase())
   const isDisabled = _isStxExecuted || isDispatchingProofs || !isStxTransferOrUnshield && (!isNext || !sdk || expiredSwap || isPending)
 
+  useEffect(() => {
+    (async () => {
+      if (isStxTransferOrUnshield) {
+        try {
+          setIsDispatchingProofs(true)
+
+          console.log("$$$$$ stxType", stxType, "stxType === STXType.Withdrawal", stxType === STXType.Withdrawal)
+          if (stxType === STXType.Transfer) {
+            await dispatchShieldedTransfer(keyPair, safe.address.value, txSummary)
+          } else if (stxType === STXType.Withdrawal) {
+            await dispatchShieldedWithdrawal(keyPair, safe.address.value, txSummary)
+          } else {
+            throw Error("Unexpected stx type " + stxType)
+          }
+
+          saveStxExecuted(txSummary.txHash!.toLowerCase())
+        } catch (err) {
+          console.error(err)
+        } finally {
+          setIsDispatchingProofs(false)
+        }
+      }
+    })()
+  }, [
+    keyPair,
+    stxType,
+    txSummary,
+    saveStxExecuted,
+    safe.address.value,
+    isStxTransferOrUnshield,
+  ])
+
   const onClick = async (e: SyntheticEvent) => {
     e.stopPropagation()
     e.preventDefault()
 
-    if (isStxTransferOrUnshield) {
-      try {
-        setIsDispatchingProofs(true)
-        console.log(isDispatchingProofs)
-        console.log("$$$$$ stxType", stxType, "stxType === STXType.Withdrawal", stxType === STXType.Withdrawal)
-        if (stxType === STXType.Transfer) {
-          await dispatchShieldedTransfer(keyPair, safe.address.value, txSummary)
-        } else if (stxType === STXType.Withdrawal) {
-          await dispatchShieldedWithdrawal(keyPair, safe.address.value, txSummary)
-        } else {
-          throw Error("Unexpected stx type " + stxType)
-        }
-
-        saveStxExecuted(txSummary.txHash!.toLowerCase())
-      } catch (err) {
-        console.error(err)
-      } finally {
-        setIsDispatchingProofs(false)
-      }
-      console.log(isDispatchingProofs)
-    } else {
-      setTxFlow(<ConfirmTxFlow txSummary={txSummary} />, undefined, false)
-    }
+    setTxFlow(<ConfirmTxFlow txSummary={txSummary} />, undefined, false)
   }
 
   const onMouseEnter = () => {

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/StatusStepper.tsx
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/StatusStepper.tsx
@@ -5,7 +5,15 @@ import StatusStep from '@/components/new-safe/create/steps/StatusStep/StatusStep
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { PendingStatus } from '@/store/pendingTxsSlice'
 
-const StatusStepper = ({ status, txHash }: { status?: PendingStatus; txHash?: string }) => {
+const StatusStepper = ({
+  status,
+  txHash,
+  isProving = undefined,
+}: {
+  status?: PendingStatus
+  txHash?: string
+  isProving?: boolean
+}) => {
   const { safeAddress } = useSafeInfo()
 
   const isProcessing = status === PendingStatus.PROCESSING || status === PendingStatus.INDEXING || status === undefined
@@ -56,6 +64,15 @@ const StatusStepper = ({ status, txHash }: { status?: PendingStatus; txHash?: st
           </Typography>
         </StatusStep>
       </Step>
+      {isProving !== undefined && (
+        <Step>
+          <StatusStep isLoading={isProving} safeAddress={safeAddress}>
+            <Typography variant="body2" fontWeight="700">
+              {isProving ? 'Proving' : 'Proof Generated'}
+            </Typography>
+          </StatusStep>
+        </Step>
+      )}
     </Stepper>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -24,6 +24,8 @@ import { NESTED_SAFE_EVENTS, NESTED_SAFE_LABELS } from '@/services/analytics/eve
 import Track from '@/components/common/Track'
 import { STXType, useBermuda } from '@/contexts/bermuda-context'
 import { useRouter } from 'next/router'
+import { dispatchShieldedTransfer } from '@/services/bermuda/dispatchShieldedTransfer'
+import { dispatchShieldedWithdrawal } from '@/services/bermuda/dispatchShieldedWithdrawal'
 
 interface Props {
   /** The ID assigned to the transaction in the client-gateway */
@@ -39,16 +41,40 @@ const SuccessScreen = ({ txId, txHash }: Props) => {
   const chain = useCurrentChain()
   const router = useRouter()
   const dispatch = useAppDispatch()
-  const { stxType } = useBermuda()
+  const { keyPair, stxType, saveStxExecuted, isStxExecuted } = useBermuda()
   const pendingTx = useAppSelector((state) => (txId ? selectPendingTxById(state, txId) : undefined))
   const { safeAddress } = useSafeInfo()
   const status = !txId && txHash ? PendingStatus.INDEXING : pendingTx?.status
   const pendingTxHash = pendingTx && 'txHash' in pendingTx ? pendingTx.txHash : undefined
   const txLink = chain && txId && getTxLink(txId, chain, safeAddress)
   const [txDetails] = useTxDetails(txId)
-  // const [isShieldedDeposit, setIsShieldedDeposit] = useState<boolean>(true)
   const isSwapOrder = txDetails && isSwapTransferOrderTxInfo(txDetails.txInfo)
   const [predictedSafeAddress] = usePredictSafeAddressFromTxDetails(txDetails)
+  const [isDispatchingProofs, setIsDispatchingProofs] = useState<boolean | undefined>(undefined)
+
+  useEffect(() => {
+    (async () => {
+      if (localTxHash && !isStxExecuted(localTxHash.toLowerCase()) && (stxType === STXType.Transfer || stxType === STXType.Withdrawal)) {
+        try {
+          setIsDispatchingProofs(true)
+
+          if (stxType === STXType.Transfer) {
+            await dispatchShieldedTransfer(keyPair, safeAddress, localTxHash)
+          } else if (stxType === STXType.Withdrawal) {
+            await dispatchShieldedWithdrawal(keyPair, safeAddress, localTxHash)
+          } else {
+            throw Error("Unexpected stx type " + stxType)
+          }
+
+          saveStxExecuted(localTxHash.toLowerCase())
+        } catch (err) {
+          setError(err as Error)
+        } finally {
+          setIsDispatchingProofs(false)
+        }
+      }
+    })()
+  }, [localTxHash, keyPair, safeAddress, stxType, isStxExecuted, saveStxExecuted])
 
   // useEffect(() => {
   //   async function run() {
@@ -99,7 +125,7 @@ const SuccessScreen = ({ txId, txHash }: Props) => {
   const spinnerStatus = error ? SpinnerStatus.ERROR : isSuccess ? SpinnerStatus.SUCCESS : SpinnerStatus.PROCESSING
 
   useEffect(() => {
-    if (isSuccess && (stxType === STXType.Transfer || stxType === STXType.Withdrawal)) {
+    if (localTxHash && isStxExecuted(localTxHash.toLowerCase()) && (stxType === STXType.Transfer || stxType === STXType.Withdrawal)) {
       dispatch(
         showNotification({
           title: 'Success',
@@ -109,14 +135,14 @@ const SuccessScreen = ({ txId, txHash }: Props) => {
         }),
       )
     }
-  }, [isSuccess, stxType])
+  }, [localTxHash, stxType, dispatch, isStxExecuted])
 
   useEffect(() => {
-    if (isSuccess && (stxType === STXType.Transfer || stxType === STXType.Withdrawal) && router.isReady) {
+    if (localTxHash && isStxExecuted(localTxHash.toLowerCase()) && (stxType === STXType.Transfer || stxType === STXType.Withdrawal) && router.isReady) {
       setTxFlow(undefined)
-      router.push(`/transactions/queue?safe=dev:${safeAddress}`)
+      router.push(`/balances/?safe=dev:${safeAddress}`)
     }
-  }, [isSuccess, stxType, router.isReady])
+  }, [localTxHash, stxType, router, setTxFlow, safeAddress, isStxExecuted])
 
   let StatusComponent
   switch (status) {
@@ -151,7 +177,7 @@ const SuccessScreen = ({ txId, txHash }: Props) => {
         <>
           <Divider />
           <div className={css.row}>
-            <StatusStepper status={status} txHash={localTxHash} />
+            <StatusStepper status={status} txHash={localTxHash} isProving={isDispatchingProofs} />
           </div>
         </>
       )}

--- a/apps/web/src/services/bermuda/dispatchShieldedTransfer.ts
+++ b/apps/web/src/services/bermuda/dispatchShieldedTransfer.ts
@@ -1,18 +1,17 @@
-import { TransactionSummary } from "@safe-global/safe-gateway-typescript-sdk";
 import { queryFilterBatched, shieldedAddressFromSpendingPubkey, simpleDecodeStx } from "./utils";
 import { Contract, getBytes, ZeroHash } from "ethers";
 import { getBermudaSDK } from "@/hooks/bermudaSDK/useBermudaSDK";
 
-export async function dispatchShieldedTransfer(shieldedKeyPair: any, safeAddress: string, txSummary: TransactionSummary) {
+export async function dispatchShieldedTransfer(shieldedKeyPair: any, safeAddress: string, txHash: string | null) {
     // const { safeAddress } = useSafeInfo()
     const bermudaSDK = getBermudaSDK()
 
     // List all MessageCiphertext events, try decrypt, then decode, then stxhash
-    // If the resulting stxhash is included in txSummary.data (SignMsgHash data) 
-    // its most likely the preimage corresponding to the stx hash that got 
-    // "signed" thru the multisig 
-    console.log("$$$$$ txSummary.txHash", txSummary.txHash)
-    const signMsgHashTx = await bermudaSDK.config.provider.getTransaction(txSummary.txHash)
+    // If the resulting stxhash is included in txSummary.data (SignMsgHash data)
+    // its most likely the preimage corresponding to the stx hash that got
+    // "signed" thru the multisig
+    console.log("$$$$$ txHash", txHash)
+    const signMsgHashTx = await bermudaSDK.config.provider.getTransaction(txHash)
     if (!signMsgHashTx) throw Error("Cannot find SignMsgHashLib tx")
 
     const encryptionKey = shieldedKeyPair.x25519.secretKey
@@ -74,8 +73,8 @@ export async function dispatchShieldedTransfer(shieldedKeyPair: any, safeAddress
     }
 
     //NOTE We load all registered peers from tehe regsitry here once
-    // so that all subsequent shieldedAddressFromSpendingPubkey() invocations 
-    // have the fresh registry available. sdk.registry.load() internally 
+    // so that all subsequent shieldedAddressFromSpendingPubkey() invocations
+    // have the fresh registry available. sdk.registry.load() internally
     // concats loaded shielded addresses to sdk.config.peers
     await bermudaSDK.registry.load()
 

--- a/apps/web/src/services/bermuda/dispatchShieldedWithdrawal.ts
+++ b/apps/web/src/services/bermuda/dispatchShieldedWithdrawal.ts
@@ -1,18 +1,17 @@
-import { TransactionSummary } from "@safe-global/safe-gateway-typescript-sdk";
 import { queryFilterBatched, shieldedAddressFromSpendingPubkey, simpleDecodeStx } from "./utils";
 import { Contract, getBytes, ZeroHash } from "ethers";
 import { getBermudaSDK } from "@/hooks/bermudaSDK/useBermudaSDK";
 
-export async function dispatchShieldedWithdrawal(shieldedKeyPair: any, safeAddress: string, txSummary: TransactionSummary) {
+export async function dispatchShieldedWithdrawal(shieldedKeyPair: any, safeAddress: string, txHash: string | null) {
     // const { safeAddress } = useSafeInfo()
     const bermudaSDK = getBermudaSDK()
 
     // List all MessageCiphertext events, try decrypt, then decode, then stxhash
-    // If the resulting stxhash is included in txSummary.data (SignMsgHash data) 
-    // its most likely the preimage corresponding to the stx hash that got 
-    // "signed" thru the multisig 
-    console.log("$$$$$ txSummary.txHash", txSummary.txHash)
-    const signMsgHashTx = await bermudaSDK.config.provider.getTransaction(txSummary.txHash)
+    // If the resulting stxhash is included in txSummary.data (SignMsgHash data)
+    // its most likely the preimage corresponding to the stx hash that got
+    // "signed" thru the multisig
+    console.log("$$$$$ txHash", txHash)
+    const signMsgHashTx = await bermudaSDK.config.provider.getTransaction(txHash)
     if (!signMsgHashTx) throw Error("Cannot find SignMsgHashLib tx")
 
     const encryptionKey = shieldedKeyPair.x25519.secretKey
@@ -76,8 +75,8 @@ export async function dispatchShieldedWithdrawal(shieldedKeyPair: any, safeAddre
     }
 
     //NOTE We load all registered peers from tehe regsitry here once
-    // so that all subsequent shieldedAddressFromSpendingPubkey() invocations 
-    // have the fresh registry available. sdk.registry.load() internally 
+    // so that all subsequent shieldedAddressFromSpendingPubkey() invocations
+    // have the fresh registry available. sdk.registry.load() internally
     // concats loaded shielded addresses to sdk.config.peers
     await bermudaSDK.registry.load()
 


### PR DESCRIPTION
Auto-run the stx finalization logic when doing a shielded transfer or withdrawal. This saves the user an additional click as they don't have to initiate the finalization themselves anymore by clicking an additional button.

Closes #69 

**Note:** Don't merge this PR as it includes the more sophisticated logic where proof generation is run as part of the `SuccessScreen` component. This needs more thorough testing as it's more complex. We should keep this PR around for future reference in case we opt for this kind of implementation (vs. the simple "auto-click" button logic which is also included as an individual commit in this PR).

Refs #74