### PR TITLE
fix: toggle contribute button when changing signer

### DIFF
--- a/apps/web/src/components/settings/ShieldedAccount/index.tsx
+++ b/apps/web/src/components/settings/ShieldedAccount/index.tsx
@@ -1,26 +1,36 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { BrowserProvider, Interface, ZeroAddress, getBytes } from 'ethers'
-import { Alert, Box, Button, CircularProgress, Grid, Paper, Stack, SxProps, TextField, Tooltip, Typography } from '@mui/material'
-import useSafeInfo from '@/hooks/useSafeInfo'
-import { useBermuda } from '@/contexts/bermuda-context'
 import { shortenHex } from '@/utils/misc'
 import { copyToClipboard } from './utils'
+import useSafeInfo from '@/hooks/useSafeInfo'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { OperationType } from '@safe-global/types-kit'
+import { useBermuda } from '@/contexts/bermuda-context'
+import React, { useEffect, useMemo, useState } from 'react'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
+import { getSafeTxHash } from '@/services/tx/tx-sender/utils'
+import { BrowserProvider, Interface, ZeroAddress, getBytes } from 'ethers'
 import {
   buildDeployment,
   calcAddress,
   CREATE_CALL_LIB,
   createCeremonyHelper,
-  getBlocking,
   getOwners,
   isDeployed,
   isReady as isMpecdhReady,
 } from '@/services/mpecdh'
-import { getSafeTxHash } from '@/services/tx/tx-sender/utils'
-import { getUserNonce } from '@/hooks/wallets/web3'
-import { OperationType } from '@safe-global/types-kit'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Grid,
+  Paper,
+  Stack,
+  SxProps,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
 
 export default function ShieldedAccount({ sx }: { sx: SxProps }) {
   const { safe, safeAddress } = useSafeInfo()
@@ -89,6 +99,12 @@ export default function ShieldedAccount({ sx }: { sx: SxProps }) {
     }
   }, [alias])
 
+  const canContribute = useMemo(() => {
+    if (!signer?.address) return false
+    if (mpecdhAddress && !isReady && blocking.length === 0) return true
+    return blocking.some((addr) => addr.toLowerCase() === signer.address.toLowerCase())
+  }, [signer?.address, blocking, mpecdhAddress, isReady])
+
   async function refreshMpecdhState() {
     if (!safeAddress) return
     const provider = web3ReadOnly ?? browserProvider
@@ -155,52 +171,58 @@ export default function ShieldedAccount({ sx }: { sx: SxProps }) {
     }
   }, [isReady])
 
-useEffect(() => {
-  if (isReady && !keyPair && !isLoading && mpecdhAddress && browserProvider && signer && sdk) {
-    const deriveSeed = async () => {
-      setIsLoading(true)
-      setDeriveError(undefined)
-      try {
-        const helper = await createCeremonyHelper(mpecdhAddress, browserProvider)
-        const ethersSigner = await browserProvider.getSigner()
-        const seedHex = await helper.stepX(ethersSigner)
-        const seed = getBytes(seedHex)
-        const nextKeyPair = sdk.types.KeyPair.fromSeed(seed)
-        const shieldedAddress = nextKeyPair.address()
-        const isRegistered = await sdk.registry.isRegistered(shieldedAddress)
-
-        if (!isRegistered) {
-          const chainId = sdk.config.chainId
-          const target = await sdk.config.registry.getAddress()
-          const data = Interface.from([
-            'function _register(address _nativeAddress, bytes calldata _shieldedAddress, bytes calldata _name) external',
-          ]).encodeFunctionData('_register', [
-            safeAddress,
-            Buffer.from(shieldedAddress.replace('0x', ''), 'hex'),
-            Buffer.alloc(0),
-          ])
-          const tx = await sdk.utils.relay(sdk.config.relayer, { chainId, target, data })
-          const receipt = await sdk.config.provider.waitForTransaction(tx)
-          if (receipt.status === 0) {
-            throw new Error(`Registry Transaction ${tx} reverted`)
-          }
-        }
-
-        const nativeAddress = await sdk.registry.nativeAddressOf(shieldedAddress)
-        if (nativeAddress.toLowerCase() !== safeAddress.toLowerCase()) {
-          throw new Error('KeyPair already registered with different Safe')
-        }
-
-        saveKeyPair(nextKeyPair)
-      } catch (error: unknown) {
-        setDeriveError(error as Error)
-      } finally {
-        setIsLoading(false)
-      }
+  useEffect(() => {
+    if (signer && canContribute) {
+      setHasContributed(false)
     }
-    void deriveSeed()
-  }
-}, [isReady, keyPair, isLoading, mpecdhAddress, browserProvider, signer, sdk, safeAddress])
+  }, [signer, canContribute])
+
+  useEffect(() => {
+    if (isReady && !keyPair && !isLoading && mpecdhAddress && browserProvider && signer && sdk) {
+      const deriveSeed = async () => {
+        setIsLoading(true)
+        setDeriveError(undefined)
+        try {
+          const helper = await createCeremonyHelper(mpecdhAddress, browserProvider)
+          const ethersSigner = await browserProvider.getSigner()
+          const seedHex = await helper.stepX(ethersSigner)
+          const seed = getBytes(seedHex)
+          const nextKeyPair = sdk.types.KeyPair.fromSeed(seed)
+          const shieldedAddress = nextKeyPair.address()
+          const isRegistered = await sdk.registry.isRegistered(shieldedAddress)
+
+          if (!isRegistered) {
+            const chainId = sdk.config.chainId
+            const target = await sdk.config.registry.getAddress()
+            const data = Interface.from([
+              'function _register(address _nativeAddress, bytes calldata _shieldedAddress, bytes calldata _name) external',
+            ]).encodeFunctionData('_register', [
+              safeAddress,
+              Buffer.from(shieldedAddress.replace('0x', ''), 'hex'),
+              Buffer.alloc(0),
+            ])
+            const tx = await sdk.utils.relay(sdk.config.relayer, { chainId, target, data })
+            const receipt = await sdk.config.provider.waitForTransaction(tx)
+            if (receipt.status === 0) {
+              throw new Error(`Registry Transaction ${tx} reverted`)
+            }
+          }
+
+          const nativeAddress = await sdk.registry.nativeAddressOf(shieldedAddress)
+          if (nativeAddress.toLowerCase() !== safeAddress.toLowerCase()) {
+            throw new Error('KeyPair already registered with different Safe')
+          }
+
+          saveKeyPair(nextKeyPair)
+        } catch (error: unknown) {
+          setDeriveError(error as Error)
+        } finally {
+          setIsLoading(false)
+        }
+      }
+      void deriveSeed()
+    }
+  }, [isReady, keyPair, isLoading, mpecdhAddress, browserProvider, signer, sdk, safeAddress])
 
   useEffect(() => {
     void refreshStatus()
@@ -208,31 +230,30 @@ useEffect(() => {
 
   async function refreshRoundInfo() {
     if (!mpecdhAddress || !browserProvider || !signer || isReady) return
-    
+
     try {
       const owners = await getOwners(safeAddress, browserProvider)
       const total = owners.length - 1
       setTotalRounds(total)
-      
+
       const { Contract } = await import('ethers')
       const mpecdhContract = new Contract(
         mpecdhAddress,
         [
           'function processed(uint256) public view returns (uint256)',
-          'function source(address) public view returns (uint256)'
+          'function source(address) public view returns (uint256)',
         ],
-        browserProvider
+        browserProvider,
       )
-      
+
       const signerSlot = await mpecdhContract.source(signer.address)
       const processedCount = await mpecdhContract.processed(signerSlot)
-      
+
       const current = Number(processedCount) + 1
-      
+
       if (current <= total) {
         setCurrentRound(current)
       }
-      
     } catch (error) {
       console.error('Failed to fetch round info', error)
     }
@@ -241,9 +262,7 @@ useEffect(() => {
     void refreshRoundInfo()
   }, [mpecdhAddress, browserProvider, isReady, blocking])
 
-
   async function handleContribute(event: React.FormEvent) {
-
     event.preventDefault()
     if (!mpecdhAddress || !browserProvider || !signer) {
       setRegisterError(new Error('Connect a signer and ensure MPECDH is deployed'))
@@ -265,11 +284,11 @@ useEffect(() => {
         setRegisterError(new Error('No contribution needed right now'))
         return
       }
-      
+
       if (txResponse?.hash) {
         await browserProvider.waitForTransaction(txResponse.hash)
       }
-      
+
       setHasContributed(true)
       await refreshStatus()
       await refreshMpecdhState()
@@ -281,9 +300,7 @@ useEffect(() => {
     }
   }
 
-
   async function handleDeploy(event: React.FormEvent) {
-
     event.preventDefault()
     if (!browserProvider || !signer || !sdk) {
       setRegisterError(new Error('Connect a signer wallet'))
@@ -296,7 +313,7 @@ useEffect(() => {
       const owners = await getOwners(safeAddress, web3ReadOnly ?? browserProvider)
       const txData = buildDeployment(safeAddress, owners)
 
-        const safeNonce = safe.nonce
+      const safeNonce = safe.nonce
       const tx = {
         value: 0n,
         operation: OperationType.Call,
@@ -306,7 +323,7 @@ useEffect(() => {
         gasToken: ZeroAddress,
         refundReceiver: ZeroAddress,
         nonce: safeNonce,
-        ...txData
+        ...txData,
       }
       const safeTxHash = await getSafeTxHash(safeAddress, tx)
       console.log('safeTxHash', safeTxHash)
@@ -389,27 +406,20 @@ useEffect(() => {
     setRegisterAliasError(undefined)
   }
 
-const canContribute = useMemo(() => {
-  if (!signer?.address) return false
-  if (mpecdhAddress && !isReady && blocking.length === 0) return true
-  return blocking.some(addr => addr.toLowerCase() === signer.address.toLowerCase())
-}, [signer?.address, blocking, mpecdhAddress, isReady])
+  const isDeploymentPending = useMemo(() => {
+    if (mpecdhAddress) return false
+    if (deploymentHash) return true
 
-    const isDeploymentPending = useMemo(() => {
-    if (mpecdhAddress) return false 
-    if (deploymentHash) return true 
-    
     if (pendingTxs.length > 0 && expectedAddress && CREATE_CALL_LIB) {
       const createCallLib = CREATE_CALL_LIB.toLowerCase()
       console.log('pendingTxs', pendingTxs)
-      console.log('createCallLib', pendingTxs.some((tx: any) => 
-        tx.details?.[0]?.toLowerCase() === createCallLib
-      ))
-      return pendingTxs.some((tx: any) => 
-        tx.details?.[0]?.toLowerCase() === createCallLib
+      console.log(
+        'createCallLib',
+        pendingTxs.some((tx: any) => tx.details?.[0]?.toLowerCase() === createCallLib),
       )
+      return pendingTxs.some((tx: any) => tx.details?.[0]?.toLowerCase() === createCallLib)
     }
-    
+
     return false
   }, [mpecdhAddress, deploymentHash, pendingTxs, expectedAddress])
 
@@ -444,27 +454,32 @@ const canContribute = useMemo(() => {
               </Typography>
             )}
             {mpecdhAddress && !isReady && currentRound !== null && totalRounds !== null && (
-            <Typography variant="caption" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
-              Current round: {currentRound} | TotalRounds: {totalRounds}
-            </Typography>
+              <Typography variant="caption" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+                Current round: {currentRound} | TotalRounds: {totalRounds}
+              </Typography>
             )}
           </Stack>
-          <Box sx={{ 
-            p: 2, 
-            mt: 2,
-            backgroundColor: 'background.paper', 
-            borderRadius: 1,
-            border: '1px solid',
-            borderColor: 'divider'
-          }}>
+          <Box
+            sx={{
+              p: 2,
+              mt: 2,
+              backgroundColor: 'background.paper',
+              borderRadius: 1,
+              border: '1px solid',
+              borderColor: 'divider',
+            }}
+          >
             <Typography variant="caption" sx={{ fontSize: '0.75rem', color: 'text.secondary', display: 'block' }}>
-            How to set up your Safe's shielded account?
+              How to set up your Safe's shielded account?
             </Typography>
-            <Typography variant="caption" sx={{ fontSize: '0.75rem', color: 'text.secondary', display: 'block', mt: 0.5 }}>
+            <Typography
+              variant="caption"
+              sx={{ fontSize: '0.75rem', color: 'text.secondary', display: 'block', mt: 0.5 }}
+            >
               1. Deploy a multi-party key exchange coordination contract for your Safe (owners)
             </Typography>
             <Typography variant="caption" sx={{ fontSize: '0.75rem', color: 'text.secondary', display: 'block' }}>
-              2. Contribute to ceremony  ({safe.owners.length - 1} {safe.owners.length - 1 === 1 ? 'round' : 'rounds'})
+              2. Contribute to ceremony ({safe.owners.length - 1} {safe.owners.length - 1 === 1 ? 'round' : 'rounds'})
             </Typography>
             <Typography variant="caption" sx={{ fontSize: '0.75rem', color: 'text.secondary', display: 'block' }}>
               3. Derive seed
@@ -480,12 +495,16 @@ const canContribute = useMemo(() => {
             {deriveError && <Alert severity="error">{deriveError.message}</Alert>}
 
             {!mpecdhAddress && (
-              <Box component="form" onSubmit={handleDeploy} sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center' }}>
+              <Box
+                component="form"
+                onSubmit={handleDeploy}
+                sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center' }}
+              >
                 <Tooltip
                   title={
-                    isDeploymentPending 
-                      ? "Deployment transaction is pending. Check the Transactions list to approve and execute." 
-                      : "Deploy the MPECDH contract via Safe multisig transaction"
+                    isDeploymentPending
+                      ? 'Deployment transaction is pending. Check the Transactions list to approve and execute.'
+                      : 'Deploy the MPECDH contract via Safe multisig transaction'
                   }
                   arrow
                 >
@@ -495,7 +514,6 @@ const canContribute = useMemo(() => {
                     </Button>
                   </span>
                 </Tooltip>
-
               </Box>
             )}
 
@@ -503,34 +521,38 @@ const canContribute = useMemo(() => {
               <Box display="flex" gap={2} flexWrap="wrap" alignItems="center" justifyContent="center">
                 {!isReady && (
                   <>
-                  <Tooltip 
-                    title={!canContribute ? "Wait for the blocking address to contribute." : "Submit your contribution for the current round"}
-                    arrow
-                  >
-                  <span>
-                  <Button
-                    variant="outlined"
-                    onClick={handleContribute}
-                    disabled={isLoading ||  !canContribute || (hasContributed && blocking.length > 0)}
-                  >
-                    Contribute
-                  </Button>
-                  </span>
-                  </Tooltip>
-                  {isLoading && !hasContributed && (
-                    <Box display="flex" alignItems="center" gap={1}>
-                      <CircularProgress size={16} />
-                      <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.875rem' }}>
-                        Submitting contribution...
+                    <Tooltip
+                      title={
+                        !canContribute
+                          ? 'Wait for the blocking address to contribute.'
+                          : 'Submit your contribution for the current round'
+                      }
+                      arrow
+                    >
+                      <span>
+                        <Button
+                          variant="outlined"
+                          onClick={handleContribute}
+                          disabled={isLoading || !canContribute || (hasContributed && blocking.length > 0)}
+                        >
+                          Contribute
+                        </Button>
+                      </span>
+                    </Tooltip>
+                    {isLoading && !hasContributed && (
+                      <Box display="flex" alignItems="center" gap={1}>
+                        <CircularProgress size={16} />
+                        <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.875rem' }}>
+                          Submitting contribution...
+                        </Typography>
+                      </Box>
+                    )}
+                    {hasContributed && (
+                      <Typography variant="body2" sx={{ color: 'success.main', fontSize: '0.875rem' }}>
+                        Contribution submitted.
                       </Typography>
-                    </Box>
-                  )}
-                  {hasContributed && (
-                    <Typography variant="body2" sx={{ color: 'success.main', fontSize: '0.875rem' }}>
-                      Contribution submitted.
-                    </Typography>
-                  )}
-                    </>
+                    )}
+                  </>
                 )}
                 {isReady && !keyPair && isLoading && (
                   <Box display="flex" alignItems="center" gap={1}>
@@ -546,7 +568,11 @@ const canContribute = useMemo(() => {
             {keyPair ? (
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px', width: '320px' }}>
                 {registerAliasError && <Alert severity="error">{registerAliasError.message}</Alert>}
-                <Typography title="Click to copy" onClick={(e) => copyToClipboard(keyPair.address(), e)} sx={{ cursor: 'copy' }}>
+                <Typography
+                  title="Click to copy"
+                  onClick={(e) => copyToClipboard(keyPair.address(), e)}
+                  sx={{ cursor: 'copy' }}
+                >
                   <Box component="span" fontWeight="bold">
                     Address
                   </Box>
@@ -588,7 +614,7 @@ const canContribute = useMemo(() => {
               </Box>
             ) : (
               <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
-                  Complete the shielded account setup to enable shielded transactions.
+                Complete the shielded account setup to enable shielded transactions.
               </Typography>
             )}
           </Box>


### PR DESCRIPTION
This PR enables / disables the "Contribute" button depending on the signer selection.

If the signer hasn't contributed yet and is the one that's currently waited for, then button will be enabled. Otherwise it's disabled (if one has already contributed).

I implemented this change so that one can switch the signer and doesn't need to reload the page for the button to become enabled again.

I also ran Prettier as the file had some formatting issues, so a lot of the "changes" are just indentation / whitespace elimination.